### PR TITLE
Refactor: signup #14

### DIFF
--- a/webapp/src/apiAction/auth.js
+++ b/webapp/src/apiAction/auth.js
@@ -14,21 +14,8 @@ export function handleLogin(dataTosubmit) {
 
 export async function handleSignUp(dataTosubmit) {
   return (dispatch) => {
-    const { name, nickname, email, password } = dataTosubmit;
-    const test = {
-      content: '12341234!@#abc',
-      hope_session: 'string',
-      img: 'string',
-      job: 'string',
-      portfolio: 'string',
-      skills: ['string'],
-      slogan: 'string',
-      name: nickname,
-      pwd: password,
-      email,
-    };
     return authApi
-      .POST_SIGN_UP(test)
+      .POST_SIGN_UP(dataTosubmit)
       .then((response) => dispatch(actionSignUp(response)))
       .catch((error) => dispatch(catchError(error)));
   };

--- a/webapp/src/components/MdEditor/index.jsx
+++ b/webapp/src/components/MdEditor/index.jsx
@@ -1,32 +1,25 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import { Editor, Viewer } from '@toast-ui/react-editor';
 
 function MarkdownEditor({ mdValue, setContent }) {
-  console.log(mdValue);
   const editorRef = useRef(null);
-  const onChangeEditorTextHandler = () => {
-    // const result = editorRef.current?.getInstance().getMarkdown();
+  const onChangeEditorTextHandler = useCallback(() => {
     setContent(editorRef.current?.getInstance().getMarkdown());
-    console.log(editorRef.current?.getInstance().getMarkdown());
-  };
+  }, [setContent]);
   return (
-    <>
-      <div>
-        <Editor
-          initialValue={mdValue}
-          previewStyle="vertical"
-          height="400px"
-          initialEditType="markdown"
-          useCommandShortcut
-          ref={editorRef}
-          onChange={onChangeEditorTextHandler}
-        />
-      </div>
-      {/* <button onClick={handleSubmit}>버튼</button>
-      <Viewer initialValue={mdValue} /> */}
-    </>
+    <div>
+      <Editor
+        initialValue={mdValue}
+        previewStyle="vertical"
+        height="400px"
+        initialEditType="markdown"
+        useCommandShortcut
+        ref={editorRef}
+        onChange={onChangeEditorTextHandler}
+      />
+    </div>
   );
 }
 

--- a/webapp/src/components/Navigation/LoginNav.jsx
+++ b/webapp/src/components/Navigation/LoginNav.jsx
@@ -16,13 +16,11 @@ import {
   USERS_LIST,
   USER_BOARD,
 } from 'constant/route';
-import { DEFAULT_PROFILE_IMG } from 'constant';
 import { Ul } from './style';
 
 function LoginNav({ userInfo }) {
   const navigate = useNavigate();
-  const { name, img } = userInfo;
-  const image = (!img || img === 'string') && DEFAULT_PROFILE_IMG;
+  const { name, img: image } = userInfo;
   const [showModal, onCloseModal, openModal] = useModal();
   const triggerLogOut = useCallback(() => {
     removeLoginCookie();

--- a/webapp/src/components/Navigation/index.jsx
+++ b/webapp/src/components/Navigation/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { getCookie } from 'utils/cookie';
+import { getUserCookie } from 'utils/cookie';
 import LoginNav from './LoginNav';
 import NonLoginNav from './NonLoginNav';
 import { NavWrapper } from './style';
 
 function Navigation() {
-  const userInfo = getCookie('userInfo');
+  const userInfo = getUserCookie();
   return <NavWrapper>{userInfo ? <LoginNav userInfo={userInfo} /> : <NonLoginNav />}</NavWrapper>;
 }
 

--- a/webapp/src/pages/SignUp/index.jsx
+++ b/webapp/src/pages/SignUp/index.jsx
@@ -1,45 +1,54 @@
-import { handleSignUp } from 'apiAction/auth';
-import { isStatusOk } from 'constant/serverStatus';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import { handleSignUp } from 'apiAction/auth';
+import { isStatusOk } from 'constant/serverStatus';
+
 import MarkdownEditor from 'components/MdEditor';
 
 function SignUp() {
+  const skillOptions = [
+    { id: 0, value: 'javascript', label: 'javascript' },
+    { id: 1, value: 'java', label: 'java' },
+    { id: 2, value: 'typescript', label: 'typescript' },
+    { id: 3, value: 'python', label: 'python' },
+    { id: 4, value: 'react', label: 'react' },
+    { id: 5, value: 'spring', label: 'spring' },
+    { id: 6, value: 'xd', label: 'xd' },
+  ];
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const [userName, setName] = useState('');
-  const [userImg, setImg] = useState('');
-  const [userJob, setJob] = useState('');
-  const [userPortfolio, setPortfolio] = useState('');
-  const [userSkill, setSkill] = useState('');
-  const [userSlogan, setSlogan] = useState('');
+  const [userName, setUserName] = useState('');
+  const [userImg, setUserImg] = useState('');
+  const [userJob, setUserJob] = useState('');
+  const [userPortfolio, setUserPortfolio] = useState('');
+  const [userSkill, setUserSkill] = useState('');
+  const [userSlogan, setUserSlogan] = useState('');
   const [mdcontent, setContent] = useState('');
-  const onNameChange = (e) => {
-    setName(e.target.value);
-  };
-  const onImgChange = (e) => {
-    setImg(e.target.value);
-  };
-  const onJobChange = (e) => {
-    setJob(e.target.value);
-  };
-  const onPortfolioChange = (e) => {
-    setPortfolio(e.target.value);
-  };
-  const onSkillChange = (e) => {
-    setSkill(e.target.value);
-  };
-  const onSloganChange = (e) => {
-    setSlogan(e.target.value);
-  };
+  const onNameChange = useCallback((e) => {
+    setUserName(e.target.value);
+  }, []);
+  const onImgChange = useCallback((e) => {
+    setUserImg(e.target.value);
+  }, []);
+  const onJobChange = useCallback((e) => {
+    setUserJob(e.target.value);
+  }, []);
+  const onPortfolioChange = useCallback((e) => {
+    setUserPortfolio(e.target.value);
+  }, []);
+  const onSkillChange = useCallback((e) => {
+    setUserSkill(e.target.value);
+  }, []);
+  const onSloganChange = useCallback((e) => {
+    setUserSlogan(e.target.value);
+  }, []);
   const {
     register,
     handleSubmit,
     setError,
     formState: { errors },
-    // watch,
   } = useForm({
     defaultValues: {},
   });
@@ -51,7 +60,6 @@ function SignUp() {
     const {
       payload: { status, code, data, message },
     } = await dispatch(handleSignUp(submitData));
-    console.log('\nstatus: ', status, '\ncode: ', code, '\ndata: ', data, '\nmessage: ', message);
     if (isStatusOk(status)) {
       navigate('/login');
     }
@@ -59,9 +67,6 @@ function SignUp() {
   return (
     <div>
       <form style={{ display: 'flex', flexDirection: 'column' }} onSubmit={handleSubmit(onValid)}>
-        <div>
-          <MarkdownEditor mdValue={mdcontent} setContent={setContent} />
-        </div>
         <input
           {...register('email', {
             required: 'Email is required',
@@ -73,23 +78,14 @@ function SignUp() {
           placeholder="email"
         />
         <span>{errors?.email?.message}</span>
-        <input name="원하는 세션" onChange={onNameChange} value={userName} />
-        <input type="file" name="사진" onChange={onImgChange} value={userImg} />
-        <input name="직업" onChange={onJobChange} value={userJob} />
         <input
           {...register('nickname', {
             required: '2자리 이상 닉네임을 입력해주세요.',
             minLength: 2,
-            validate: {
-              // async로 만들어서  비동기로 서버에서 요청받을 수도 있음
-              // noYun: (value) => (value.includes('yun') ? 'no yun allowed' : true),
-              // noHo: (value) => (value.includes('ho') ? 'no ho allowed' : true),
-            },
           })}
           placeholder="nickname"
         />
         <span>{errors?.nickname?.message}</span>
-        <input type="file" name="포트폴리오" onChange={onPortfolioChange} value={userPortfolio} />
         <input
           {...register('password', {
             required: '4자리 이상 비밀번호를 입력해주세요.',
@@ -110,9 +106,26 @@ function SignUp() {
           placeholder="verifiedPassword"
         />
         <span>{errors?.verifiedPassword?.message}</span>
-        <input name="능력" onChange={onSkillChange} value={userSkill} />
-        <input name="슬로건" onChange={onSloganChange} value={userSlogan} />
+        <span>기술 스킬 </span>
+        <select value={userSkill} onChange={onSkillChange}>
+          {skillOptions.map(({ id, value, label }) => (
+            <option key={id} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <input name="slogan" onChange={onSloganChange} value={userSlogan} placeholder="slogan" />
+        <input name="job" onChange={onJobChange} value={userJob} placeholder="직업" />
+        <input
+          name="portfolio"
+          onChange={onPortfolioChange}
+          value={userPortfolio}
+          placeholder="포트폴리오"
+        />
         <button>가입</button>
+        <div>
+          <MarkdownEditor mdValue={mdcontent} setContent={setContent} />
+        </div>
         <span>{errors?.extraError?.message}</span>
       </form>
     </div>

--- a/webapp/src/pages/SignUp/index.jsx
+++ b/webapp/src/pages/SignUp/index.jsx
@@ -64,6 +64,7 @@ function SignUp() {
       userSlogan,
       mdcontent,
     };
+    console.log(signUpInfo);
     // TODO: input validation 추가해야함.
     const {
       payload: { status, code, data, message },

--- a/webapp/src/pages/SignUp/index.jsx
+++ b/webapp/src/pages/SignUp/index.jsx
@@ -6,6 +6,7 @@ import { handleSignUp } from 'apiAction/auth';
 import { isStatusOk } from 'constant/serverStatus';
 
 import MarkdownEditor from 'components/MdEditor';
+import useInput from 'hooks/useInput';
 
 const skillOptions = [
   { id: 0, value: 'javascript', label: 'javascript' },
@@ -27,32 +28,18 @@ const hopeSessionOption = [
 function SignUp() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const [userImg, setUserImg] = useState('');
-  const [userJob, setUserJob] = useState('');
-  const [userPortfolio, setUserPortfolio] = useState('');
-  const [userSkill, setUserSkill] = useState('');
+  const [userImg, onImgChange] = useInput('');
+  const [userJob, onJobChange] = useInput('');
+  const [userPortfolio, onPortfolioChange] = useInput('');
+  const [hopeSession, onHopeSessionChange] = useInput('무관');
+  const [userSlogan, onSloganChange] = useInput('');
+  const [userSkill, setUserSkill] = useInput('');
+  const [mdcontent, setMdContent] = useInput('');
+
   const [selectedSkills, setSelectedSkills] = useState([]);
-  const [hopeSession, setHopeSession] = useState('무관');
-  const [userSlogan, setUserSlogan] = useState('');
-  const [mdcontent, setMdContent] = useState('');
-  const onImgChange = useCallback((e) => {
-    setUserImg(e.target.value);
-  }, []);
-  const onJobChange = useCallback((e) => {
-    setUserJob(e.target.value);
-  }, []);
-  const onPortfolioChange = useCallback((e) => {
-    setUserPortfolio(e.target.value);
-  }, []);
   const onSkillChange = useCallback((e) => {
     setUserSkill(e.target.value);
     setSelectedSkills((prev) => [...prev, e.target.value]);
-  }, []);
-  const onHopeSessionChange = useCallback((e) => {
-    setHopeSession(e.target.value);
-  }, []);
-  const onSloganChange = useCallback((e) => {
-    setUserSlogan(e.target.value);
   }, []);
   const {
     register,

--- a/webapp/src/pages/SignUp/index.jsx
+++ b/webapp/src/pages/SignUp/index.jsx
@@ -7,16 +7,24 @@ import { isStatusOk } from 'constant/serverStatus';
 
 import MarkdownEditor from 'components/MdEditor';
 
+const skillOptions = [
+  { id: 0, value: 'javascript', label: 'javascript' },
+  { id: 1, value: 'java', label: 'java' },
+  { id: 2, value: 'typescript', label: 'typescript' },
+  { id: 3, value: 'python', label: 'python' },
+  { id: 4, value: 'react', label: 'react' },
+  { id: 5, value: 'spring', label: 'spring' },
+  { id: 6, value: 'xd', label: 'xd' },
+];
+const hopeSessionOption = [
+  { id: 0, value: '무관' },
+  { id: 1, value: '1개월 이하' },
+  { id: 2, value: '3개월 이하' },
+  { id: 3, value: '6개월 이하' },
+  { id: 4, value: '6개월 이상' },
+];
+
 function SignUp() {
-  const skillOptions = [
-    { id: 0, value: 'javascript', label: 'javascript' },
-    { id: 1, value: 'java', label: 'java' },
-    { id: 2, value: 'typescript', label: 'typescript' },
-    { id: 3, value: 'python', label: 'python' },
-    { id: 4, value: 'react', label: 'react' },
-    { id: 5, value: 'spring', label: 'spring' },
-    { id: 6, value: 'xd', label: 'xd' },
-  ];
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const [userImg, setUserImg] = useState('');
@@ -24,6 +32,7 @@ function SignUp() {
   const [userPortfolio, setUserPortfolio] = useState('');
   const [userSkill, setUserSkill] = useState('');
   const [selectedSkills, setSelectedSkills] = useState([]);
+  const [hopeSession, setHopeSession] = useState('무관');
   const [userSlogan, setUserSlogan] = useState('');
   const [mdcontent, setMdContent] = useState('');
   const onImgChange = useCallback((e) => {
@@ -39,6 +48,9 @@ function SignUp() {
     setUserSkill(e.target.value);
     setSelectedSkills((prev) => [...prev, e.target.value]);
   }, []);
+  const onHopeSessionChange = useCallback((e) => {
+    setHopeSession(e.target.value);
+  }, []);
   const onSloganChange = useCallback((e) => {
     setUserSlogan(e.target.value);
   }, []);
@@ -51,20 +63,22 @@ function SignUp() {
     defaultValues: {},
   });
   const onValid = async (submitData) => {
-    const { password, verifiedPassword } = submitData;
+    const { email, nickname, password, verifiedPassword } = submitData;
     if (password !== verifiedPassword) {
       setError('verifiedPassword', { message: 'Password is not same' }, { shouldFocus: true });
     }
     const signUpInfo = {
-      ...submitData,
-      userImg,
-      userJob,
-      userPortfolio,
-      selectedSkills,
-      userSlogan,
-      mdcontent,
+      email,
+      name: nickname,
+      pwd: password,
+      content: mdcontent,
+      hope_session: hopeSession,
+      img: userImg,
+      job: userJob,
+      portfolio: userPortfolio,
+      skills: selectedSkills,
+      slogan: userSlogan,
     };
-    console.log(signUpInfo);
     // TODO: input validation 추가해야함.
     const {
       payload: { status, code, data, message },
@@ -120,6 +134,14 @@ function SignUp() {
           {skillOptions.map(({ id, value, label }) => (
             <option key={id} value={value}>
               {label}
+            </option>
+          ))}
+        </select>
+        <span>희망 작업 기간</span>
+        <select value={hopeSession} onChange={onHopeSessionChange}>
+          {hopeSessionOption.map(({ id, value }) => (
+            <option key={id} value={value}>
+              {value}
             </option>
           ))}
         </select>

--- a/webapp/src/pages/SignUp/index.jsx
+++ b/webapp/src/pages/SignUp/index.jsx
@@ -19,16 +19,13 @@ function SignUp() {
   ];
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const [userName, setUserName] = useState('');
   const [userImg, setUserImg] = useState('');
   const [userJob, setUserJob] = useState('');
   const [userPortfolio, setUserPortfolio] = useState('');
   const [userSkill, setUserSkill] = useState('');
+  const [selectedSkills, setSelectedSkills] = useState([]);
   const [userSlogan, setUserSlogan] = useState('');
-  const [mdcontent, setContent] = useState('');
-  const onNameChange = useCallback((e) => {
-    setUserName(e.target.value);
-  }, []);
+  const [mdcontent, setMdContent] = useState('');
   const onImgChange = useCallback((e) => {
     setUserImg(e.target.value);
   }, []);
@@ -40,6 +37,7 @@ function SignUp() {
   }, []);
   const onSkillChange = useCallback((e) => {
     setUserSkill(e.target.value);
+    setSelectedSkills((prev) => [...prev, e.target.value]);
   }, []);
   const onSloganChange = useCallback((e) => {
     setUserSlogan(e.target.value);
@@ -57,9 +55,19 @@ function SignUp() {
     if (password !== verifiedPassword) {
       setError('verifiedPassword', { message: 'Password is not same' }, { shouldFocus: true });
     }
+    const signUpInfo = {
+      ...submitData,
+      userImg,
+      userJob,
+      userPortfolio,
+      selectedSkills,
+      userSlogan,
+      mdcontent,
+    };
+    // TODO: input validation 추가해야함.
     const {
       payload: { status, code, data, message },
-    } = await dispatch(handleSignUp(submitData));
+    } = await dispatch(handleSignUp(signUpInfo));
     if (isStatusOk(status)) {
       navigate('/login');
     }
@@ -106,7 +114,7 @@ function SignUp() {
           placeholder="verifiedPassword"
         />
         <span>{errors?.verifiedPassword?.message}</span>
-        <span>기술 스킬 </span>
+        <span>선택한 기술 스킬: {selectedSkills.join(', ')}</span>
         <select value={userSkill} onChange={onSkillChange}>
           {skillOptions.map(({ id, value, label }) => (
             <option key={id} value={value}>
@@ -114,6 +122,12 @@ function SignUp() {
             </option>
           ))}
         </select>
+        <input
+          name="profile-image"
+          onChange={onImgChange}
+          value={userImg}
+          placeholder="임시 프로필 이미지 문자열로 입력"
+        />
         <input name="slogan" onChange={onSloganChange} value={userSlogan} placeholder="slogan" />
         <input name="job" onChange={onJobChange} value={userJob} placeholder="직업" />
         <input
@@ -124,7 +138,7 @@ function SignUp() {
         />
         <button>가입</button>
         <div>
-          <MarkdownEditor mdValue={mdcontent} setContent={setContent} />
+          <MarkdownEditor mdValue={mdcontent} setContent={setMdContent} />
         </div>
         <span>{errors?.extraError?.message}</span>
       </form>

--- a/webapp/src/utils/cookie.js
+++ b/webapp/src/utils/cookie.js
@@ -1,4 +1,4 @@
-import { AUTH_KEY, USER_INFO } from 'constant';
+import { AUTH_KEY, DEFAULT_PROFILE_IMG, USER_INFO } from 'constant';
 import { Cookies } from 'react-cookie';
 
 const cookies = new Cookies();
@@ -6,6 +6,16 @@ const cookies = new Cookies();
 export const setCookie = (name, value, option) => cookies.set(name, value, { ...option });
 
 export const getCookie = (name) => cookies.get(name);
+
+export const getUserCookie = () => {
+  const userInfo = getCookie(USER_INFO);
+  if (!userInfo) {
+    return null;
+  }
+  const { img } = userInfo;
+  const image = (!img || img.length < 10) && DEFAULT_PROFILE_IMG;
+  return { ...userInfo, img: image };
+};
 
 export const getAuthCookie = () => cookies.get(AUTH_KEY);
 


### PR DESCRIPTION
## 요약 (개요)

회원가입 페이지 세부설정 추가

## 작업 내용(to-do list)
[x] 각 입력사항마다 세부적인 설정 추가
- 기술스택: string -> [string, string]
- 희망작업기간: string -> 유저 선택옵션을 추가(ex> 3개월 이상)
[x] 로그인 이후 default 이미지 로직 이동
- LoginNav.jsx -> utils/cookie.js

[  ] 현재 sign 페이지에서 모든 입력 값을 받게 되어 있는데, 구분해서 받을 필요 있음  (예시: https://holaworld.io) 


## 이슈 태그
#14 