### PR TITLE
Team 관련 API 수정 #36 #46 #37

### DIFF
--- a/src/main/java/com/projectmatching/app/controller/comment/TeamCommentController.java
+++ b/src/main/java/com/projectmatching/app/controller/comment/TeamCommentController.java
@@ -46,12 +46,22 @@ public class TeamCommentController {
         return ResponseTemplate.of(ResponseTemplateStatus.SUCCESS);
     }
 
+
+
     @ApiOperation(value = "팀 게시물 댓글에 좋아요 누르기")
-    @PostMapping("/comment/liking/{comment_id}")
-    public ResponseTemplate<Boolean> likingTeamComment(@PathVariable(name = "comment_id") Long commentId, @AuthenticationPrincipal UserDetailsImpl userDetails){
-        Boolean result = commentService.likingTeamComment(userDetails, commentId);
-        return ResponseTemplate.valueOf(result);
+    @PatchMapping("/comment/liking/{comment_id}")
+    public ResponseTemplate<Boolean> doTeamCommentLiking(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable(name = "comment_id") Long commentId){
+        commentService.doTeamCommentLiking(userDetails, commentId);
+        return ResponseTemplate.of(ResponseTemplateStatus.SUCCESS);
     }
+
+    @ApiOperation(value ="팀 게시물 댓글 좋아요 취소")
+    @DeleteMapping("/comment/unliking/{comment_id}")
+    public ResponseTemplate<Boolean> cancelTeamCommentLiking(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable(name = "comment_id") Long commentId){
+        commentService.cancelTeamCommentLiking(userDetails, commentId);
+        return ResponseTemplate.of(ResponseTemplateStatus.SUCCESS);
+    }
+
 
     @ApiOperation(value = "팀 게시글 댓글 리스트 조회")
     @GetMapping("/comment/{team_id}")

--- a/src/main/java/com/projectmatching/app/controller/team/TeamController.java
+++ b/src/main/java/com/projectmatching/app/controller/team/TeamController.java
@@ -49,8 +49,8 @@ public class TeamController {
      * team 카드들 조회
      */
     @ApiOperation(value = "team 카드 조회 API", notes = "팀 리스트를 조회합니다.")
-    @GetMapping("/teams")
-    public ResponseTemplate<List<TeamResponseDto>> getTeams(@RequestParam(name="page") int page){
+    @GetMapping("/team")
+    public ResponseTemplate<List<TeamResponseDto>> getTeams(@RequestParam(name="lastPage") int page){
         Paging paging = new Paging(page,PAGING_SIZE);
         return ResponseTemplate.valueOf(teamService.getTeams(paging));
     }

--- a/src/main/java/com/projectmatching/app/domain/comment/dto/TeamCommentDto.java
+++ b/src/main/java/com/projectmatching/app/domain/comment/dto/TeamCommentDto.java
@@ -5,6 +5,7 @@ import com.projectmatching.app.domain.comment.entity.TeamComment;
 import com.projectmatching.app.domain.liking.dto.TeamCommentLikingDto;
 import com.projectmatching.app.domain.liking.entity.TeamCommentLiking;
 import com.projectmatching.app.domain.team.entity.Team;
+import com.projectmatching.app.domain.user.dto.UserDto;
 import com.projectmatching.app.domain.user.entity.User;
 import com.projectmatching.app.util.IdGenerator;
 import lombok.*;
@@ -36,7 +37,7 @@ public class TeamCommentDto {
     @Builder.Default
     private List<TeamCommentDto> comments = new ArrayList<>();
     @Builder.Default
-    private List<TeamCommentLikingDto> feelings = new ArrayList<>();
+    private List<Long> feelings = new ArrayList<>();
 
     public static TeamCommentDto createEmpty() {
         return new TeamCommentDto();
@@ -56,8 +57,7 @@ public class TeamCommentDto {
                     .stream().map(TeamCommentDto::of).collect(Collectors.toList());
         }
 
-        teamCommentDto.feelings = teamComment.getTeamCommentLikings()
-                .stream().map(TeamCommentLikingDto::of).collect(Collectors.toList());
+        teamCommentDto.feelings = teamComment.getTeamCommentLikings().stream().map(teamCommentLiking -> teamCommentLiking.getUser().getId()).collect(Collectors.toList());
 
         return teamCommentDto;
     }
@@ -69,7 +69,6 @@ public class TeamCommentDto {
         teamComment.setComments(comments.stream()
                 .map(teamCommentDto -> teamCommentDto.asEntity()).collect(Collectors.toSet()));
 
-        teamComment.setTeamCommentLikings(mapToSet(this.feelings,TeamCommentLikingDto::asEntity));
 
         return teamComment;
     }

--- a/src/main/java/com/projectmatching/app/domain/liking/repository/TeamCommentLikingRepository.java
+++ b/src/main/java/com/projectmatching/app/domain/liking/repository/TeamCommentLikingRepository.java
@@ -4,8 +4,9 @@ import com.projectmatching.app.domain.liking.entity.TeamCommentLiking;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface TeamCommentLikingRepository extends JpaRepository<TeamCommentLiking, Long> {
-    boolean existsByUser_IdAndTeamComment_Id(Long userId, Long teamCommentId);
-    void deleteByUser_IdAndTeamComment_Id(Long userId, Long teamCommentId);
+    Optional<TeamCommentLiking> findByUser_IdAndTeamComment_Id(Long userId, Long teamCommentId);
 }

--- a/src/main/java/com/projectmatching/app/domain/team/dto/TeamDetailResponseDto.java
+++ b/src/main/java/com/projectmatching/app/domain/team/dto/TeamDetailResponseDto.java
@@ -4,6 +4,7 @@ import com.projectmatching.app.domain.comment.dto.TeamCommentDto;
 import com.projectmatching.app.domain.team.entity.Team;
 import com.projectmatching.app.domain.team.entity.TeamTech;
 import com.projectmatching.app.domain.techStack.entity.TechStack;
+import com.projectmatching.app.domain.user.dto.UserDto;
 import com.projectmatching.app.domain.user.entity.UserTeam;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -23,19 +24,18 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 public class TeamDetailResponseDto {
 
-    private Long userId;
-    private Long teamId;
+    private Long id;
+    private UserDto user;
     private String name;
     private String content;
     private String session;
     private List<String> skills;
     private String img;
     private Long read;
-    private Boolean status;
+    private String status;
     private int commentCnt;
     private int likeCnt;
-    private LocalDateTime createAt;
-    private LocalDateTime updateAt;
+
 
 
     public static TeamDetailResponseDto createEmpty(){return new TeamDetailResponseDto();}
@@ -49,7 +49,6 @@ public class TeamDetailResponseDto {
         teamResponseDto.commentCnt = team.getTeamComments().size();
         teamResponseDto.likeCnt = team.getTeamLikings().size();
 
-        teamResponseDto.status = team.getStatus()=="removed" ? Boolean.FALSE : Boolean.TRUE;
 
         return teamResponseDto;
     }

--- a/src/main/java/com/projectmatching/app/domain/team/dto/TeamRequestDto.java
+++ b/src/main/java/com/projectmatching/app/domain/team/dto/TeamRequestDto.java
@@ -24,5 +24,5 @@ public class TeamRequestDto {
     private String content;
 
     @ApiModelProperty(example = "기술 스택")
-    private List<Long> techs;
+    private List<Long> skills;
 }

--- a/src/main/java/com/projectmatching/app/domain/team/dto/TeamResponseDto.java
+++ b/src/main/java/com/projectmatching/app/domain/team/dto/TeamResponseDto.java
@@ -3,6 +3,7 @@ package com.projectmatching.app.domain.team.dto;
 import com.projectmatching.app.domain.team.entity.Team;
 import com.projectmatching.app.domain.team.entity.TeamTech;
 import com.projectmatching.app.domain.techStack.entity.TechStack;
+import com.projectmatching.app.domain.user.dto.UserDto;
 import com.projectmatching.app.domain.user.entity.UserTeam;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,8 +21,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class TeamResponseDto {
-    private Long userId;
-    private Long teamId;
+
+    private Long id;
+    private UserDto user;
     private String name;
     private String session;
     private String img;
@@ -29,7 +31,7 @@ public class TeamResponseDto {
     private int commentCnt;
     private int likeCnt;
     private List<String> skills;
-    private Boolean status;
+    private String status;
 
 
     public static TeamResponseDto createEmpty(){return new TeamResponseDto();}
@@ -43,7 +45,6 @@ public class TeamResponseDto {
         teamResponseDto.commentCnt = team.getTeamComments().size();
         teamResponseDto.likeCnt = team.getTeamLikings().size();
 
-        teamResponseDto.status = team.getStatus()=="removed" ? Boolean.FALSE : Boolean.TRUE;
 
         return teamResponseDto;
     }

--- a/src/main/java/com/projectmatching/app/service/comment/CommentService.java
+++ b/src/main/java/com/projectmatching/app/service/comment/CommentService.java
@@ -37,7 +37,8 @@ public interface CommentService {
     void cancelUserCommentLiking(UserDetailsImpl userDetails,Long commentId);
 
 
-    Boolean likingTeamComment(UserDetailsImpl userDetails, Long commentId);
+    void doTeamCommentLiking(UserDetailsImpl userDetails, Long commentId);
+    void cancelTeamCommentLiking(UserDetailsImpl userDetails, Long commentId);
 
 
 

--- a/src/main/java/com/projectmatching/app/service/team/TeamService.java
+++ b/src/main/java/com/projectmatching/app/service/team/TeamService.java
@@ -16,6 +16,7 @@ import com.projectmatching.app.domain.techStack.TechStackRepository;
 import com.projectmatching.app.domain.techStack.entity.TechStack;
 import com.projectmatching.app.domain.user.UserRepository;
 import com.projectmatching.app.domain.user.UserTeamRepository;
+import com.projectmatching.app.domain.user.dto.UserDto;
 import com.projectmatching.app.domain.user.entity.User;
 import com.projectmatching.app.domain.user.entity.UserTeam;
 import lombok.RequiredArgsConstructor;
@@ -56,7 +57,7 @@ public class TeamService {
 
             Long teamId = teamRepository.save(team).getId();
 
-            List<Long> techs = requestDto.getTechs();
+            List<Long> techs = requestDto.getSkills();
             for (Long t : techs){
                 TechStack techStack = techStackRepository.findById(t).orElseThrow(() -> new ResponeException(SAVE_TEAM_ERROR));
                 TeamTech teamTech = TeamTech.builder()
@@ -90,16 +91,11 @@ public class TeamService {
             for(Team team : teams){
                 TeamResponseDto teamResponseDto = new TeamResponseDto();
                 copyProperties(team, teamResponseDto);
-                teamResponseDto.setUserId(findTeamUser(team));
+                teamResponseDto.setUser(findTeamUser(team));
                 teamResponseDto.setSkills(findTeamTech(team));
                 teamResponseDto.setCommentCnt(team.getTeamComments().size());
                 teamResponseDto.setLikeCnt(team.getTeamLikings().size());
 
-                if(team.getStatus()=="removed") {
-                    teamResponseDto.setStatus(Boolean.FALSE);
-                } else{
-                    teamResponseDto.setStatus(Boolean.TRUE);
-                }
 
                 responseDtos.add(teamResponseDto);
             }
@@ -115,16 +111,11 @@ public class TeamService {
         try{
             TeamDetailResponseDto teamDetailResponseDto = new TeamDetailResponseDto();
             copyProperties(team, teamDetailResponseDto);
-            teamDetailResponseDto.setUserId(findTeamUser(team));
+            teamDetailResponseDto.setUser(findTeamUser(team));
             teamDetailResponseDto.setSkills(findTeamTech(team));
             teamDetailResponseDto.setCommentCnt(team.getTeamComments().size());
             teamDetailResponseDto.setLikeCnt(team.getTeamLikings().size());
 
-            if(team.getStatus()=="removed") {
-                teamDetailResponseDto.setStatus(Boolean.FALSE);
-            } else{
-                teamDetailResponseDto.setStatus(Boolean.TRUE);
-            }
 
             return teamDetailResponseDto;
         }catch (Exception e){
@@ -132,11 +123,11 @@ public class TeamService {
         }
     }
 
-    public Long findTeamUser(Team team){
+    public UserDto findTeamUser(Team team){
         List<UserTeam> userTeamList = team.getUserTeams().stream().collect(Collectors.toList());
         if(userTeamList.size() != 0) {
             UserTeam findUser = userTeamList.get(0);
-            return findUser.getUser().getId();
+            return UserDto.of(findUser.getUser());
         }
         else return null;
     }
@@ -175,7 +166,7 @@ public class TeamService {
             team.update(teamRequestDto);
             teamTechRepository.deleteAllByTeam_Id(team.getId());
 
-            List<Long> techs = teamRequestDto.getTechs();
+            List<Long> techs = teamRequestDto.getSkills();
             for (Long t : techs) {
                 TechStack techStack = techStackRepository.findById(t).orElseThrow(() -> new ResponeException(SAVE_TEAM_ERROR));
                 TeamTech teamTech = TeamTech.builder()


### PR DESCRIPTION
## 작업 내용
[x] User와 Team API 변수명 통일
[x] Team 댓글 조회시 좋아요한 유저 리스트에 유저의 id만 보이도록 수정
[x] 댓글 좋아요 등록 API의 HTTP method를 PATCH로 수정
[x] 댓글 좋아요 등록 API와 좋아요 취소 API 분리

## 테스트 결과
좋아요 취소 API Postman 테스트 완료

## 이슈 태그
#36  #46 #37