### PR TITLE
팀 게시물 좋아요&히스토리 관련 API

### DIFF
--- a/src/main/generated/com/projectmatching/app/domain/history/entity/QTeamHistory.java
+++ b/src/main/generated/com/projectmatching/app/domain/history/entity/QTeamHistory.java
@@ -1,0 +1,53 @@
+package com.projectmatching.app.domain.history.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QTeamHistory is a Querydsl query type for TeamHistory
+ */
+@Generated("com.querydsl.codegen.EntitySerializer")
+public class QTeamHistory extends EntityPathBase<TeamHistory> {
+
+    private static final long serialVersionUID = -672311874L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QTeamHistory teamHistory = new QTeamHistory("teamHistory");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.projectmatching.app.domain.user.entity.QUser user;
+
+    public final NumberPath<Long> visited = createNumber("visited", Long.class);
+
+    public QTeamHistory(String variable) {
+        this(TeamHistory.class, forVariable(variable), INITS);
+    }
+
+    public QTeamHistory(Path<? extends TeamHistory> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QTeamHistory(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QTeamHistory(PathMetadata metadata, PathInits inits) {
+        this(TeamHistory.class, metadata, inits);
+    }
+
+    public QTeamHistory(Class<? extends TeamHistory> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.projectmatching.app.domain.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/projectmatching/app/domain/history/entity/QUserHistory.java
+++ b/src/main/generated/com/projectmatching/app/domain/history/entity/QUserHistory.java
@@ -1,0 +1,53 @@
+package com.projectmatching.app.domain.history.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QUserHistory is a Querydsl query type for UserHistory
+ */
+@Generated("com.querydsl.codegen.EntitySerializer")
+public class QUserHistory extends EntityPathBase<UserHistory> {
+
+    private static final long serialVersionUID = 558748816L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QUserHistory userHistory = new QUserHistory("userHistory");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final com.projectmatching.app.domain.user.entity.QUser user;
+
+    public final NumberPath<Long> visited = createNumber("visited", Long.class);
+
+    public QUserHistory(String variable) {
+        this(UserHistory.class, forVariable(variable), INITS);
+    }
+
+    public QUserHistory(Path<? extends UserHistory> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QUserHistory(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QUserHistory(PathMetadata metadata, PathInits inits) {
+        this(UserHistory.class, metadata, inits);
+    }
+
+    public QUserHistory(Class<? extends UserHistory> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.user = inits.isInitialized("user") ? new com.projectmatching.app.domain.user.entity.QUser(forProperty("user")) : null;
+    }
+
+}
+

--- a/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechStack.java
+++ b/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechStack.java
@@ -26,6 +26,8 @@ public class QTechStack extends EntityPathBase<TechStack> {
 
     public final SetPath<com.projectmatching.app.domain.team.entity.TeamTech, com.projectmatching.app.domain.team.entity.QTeamTech> teamTechs = this.<com.projectmatching.app.domain.team.entity.TeamTech, com.projectmatching.app.domain.team.entity.QTeamTech>createSet("teamTechs", com.projectmatching.app.domain.team.entity.TeamTech.class, com.projectmatching.app.domain.team.entity.QTeamTech.class, PathInits.DIRECT2);
 
+    public final NumberPath<Long> techSerialNum = createNumber("techSerialNum", Long.class);
+
     public final NumberPath<Long> techStackId = createNumber("techStackId", Long.class);
 
     public final SetPath<com.projectmatching.app.domain.user.entity.UserTech, com.projectmatching.app.domain.user.entity.QUserTech> userTeches = this.<com.projectmatching.app.domain.user.entity.UserTech, com.projectmatching.app.domain.user.entity.QUserTech>createSet("userTeches", com.projectmatching.app.domain.user.entity.UserTech.class, com.projectmatching.app.domain.user.entity.QUserTech.class, PathInits.DIRECT2);

--- a/src/main/generated/com/projectmatching/app/domain/user/entity/QUser.java
+++ b/src/main/generated/com/projectmatching/app/domain/user/entity/QUser.java
@@ -63,6 +63,8 @@ public class QUser extends EntityPathBase<User> {
 
     public final SetPath<com.projectmatching.app.domain.comment.entity.UserComment, com.projectmatching.app.domain.comment.entity.QUserComment> userComments = this.<com.projectmatching.app.domain.comment.entity.UserComment, com.projectmatching.app.domain.comment.entity.QUserComment>createSet("userComments", com.projectmatching.app.domain.comment.entity.UserComment.class, com.projectmatching.app.domain.comment.entity.QUserComment.class, PathInits.DIRECT2);
 
+    public final SetPath<com.projectmatching.app.domain.history.entity.UserHistory, com.projectmatching.app.domain.history.entity.QUserHistory> userHistories = this.<com.projectmatching.app.domain.history.entity.UserHistory, com.projectmatching.app.domain.history.entity.QUserHistory>createSet("userHistories", com.projectmatching.app.domain.history.entity.UserHistory.class, com.projectmatching.app.domain.history.entity.QUserHistory.class, PathInits.DIRECT2);
+
     public final SetPath<com.projectmatching.app.domain.liking.entity.UserLiking, com.projectmatching.app.domain.liking.entity.QUserLiking> userLikings = this.<com.projectmatching.app.domain.liking.entity.UserLiking, com.projectmatching.app.domain.liking.entity.QUserLiking>createSet("userLikings", com.projectmatching.app.domain.liking.entity.UserLiking.class, com.projectmatching.app.domain.liking.entity.QUserLiking.class, PathInits.DIRECT2);
 
     public final SetPath<UserTeam, QUserTeam> userTeams = this.<UserTeam, QUserTeam>createSet("userTeams", UserTeam.class, QUserTeam.class, PathInits.DIRECT2);

--- a/src/main/java/com/projectmatching/app/controller/history/TeamHistoryController.java
+++ b/src/main/java/com/projectmatching/app/controller/history/TeamHistoryController.java
@@ -1,0 +1,37 @@
+package com.projectmatching.app.controller.history;
+
+import com.projectmatching.app.config.resTemplate.ResponseTemplate;
+import com.projectmatching.app.domain.team.dto.TeamResponseDto;
+import com.projectmatching.app.service.history.TeamHistoryService;
+import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/history/team")
+@Slf4j
+@RequiredArgsConstructor
+@Api(tags = "팀 히스토리 컨트롤러")
+public class TeamHistoryController {
+
+    private final TeamHistoryService teamHistoryService;
+
+    @ApiOperation(value = "히스토리 조회")
+    @GetMapping("")
+    public ResponseTemplate<List<TeamResponseDto>> getTeamHistory(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseTemplate.valueOf(teamHistoryService.getTeamHistory(userDetails));
+    }
+
+
+    @ApiOperation(value = "팀 게시글 히스토리 저장")
+    @PostMapping("/{teamId}")
+    public ResponseTemplate<Long> saveTeamHistory(@AuthenticationPrincipal UserDetailsImpl userDetails,@PathVariable(name = "teamId") Long visitedTeamId){
+        return ResponseTemplate.valueOf(teamHistoryService.savedTeamHistory(userDetails, visitedTeamId));
+    }
+}

--- a/src/main/java/com/projectmatching/app/controller/team/TeamController.java
+++ b/src/main/java/com/projectmatching/app/controller/team/TeamController.java
@@ -95,4 +95,13 @@ public class TeamController {
         Boolean result = teamService.teamLike(team_id, userDetails.getEmail());
         return ResponseTemplate.valueOf(result);
     }
+
+    /**
+     * 내가 좋아요 한 팀 목록
+     */
+    @ApiOperation(value = "내가 좋아요한 팀 목록")
+    @GetMapping("team/favorite")
+    public ResponseTemplate<List<TeamResponseDto>> getMyFavoriteTeam(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        return ResponseTemplate.valueOf(teamService.getTeamLikingList(userDetails));
+    }
 }

--- a/src/main/java/com/projectmatching/app/controller/team/TeamController.java
+++ b/src/main/java/com/projectmatching/app/controller/team/TeamController.java
@@ -2,6 +2,7 @@ package com.projectmatching.app.controller.team;
 
 
 import com.projectmatching.app.config.resTemplate.ResponseTemplate;
+import com.projectmatching.app.constant.ResponseTemplateStatus;
 import com.projectmatching.app.constant.ServiceConstant;
 import com.projectmatching.app.domain.common.Paging;
 import com.projectmatching.app.domain.team.dto.TeamDetailResponseDto;
@@ -87,13 +88,23 @@ public class TeamController {
     }
 
     /**
-     * team 좋아요 등록 및 삭제
+     * team 좋아요 등록
      */
-    @ApiOperation(value = "team 게시글 좋아요 등록 및 취소 API", notes = "팀 게시글을 수정합니다.")
-    @PostMapping("/team/liking/{team_id}")
-    public ResponseTemplate<Boolean> teamLike(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long team_id){  //user_id 부분 수정필요
-        Boolean result = teamService.teamLike(team_id, userDetails.getEmail());
-        return ResponseTemplate.valueOf(result);
+    @ApiOperation(value = "team 게시글 좋아요 등록", notes = "팀 게시글 좋아요 등록")
+    @PatchMapping("/team/liking/{team_id}")
+    public ResponseTemplate<Boolean> doTeamLiking(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable(name = "team_id") Long teamId){
+        teamService.doTeamLiking(userDetails, teamId);
+        return ResponseTemplate.of(ResponseTemplateStatus.SUCCESS);
+    }
+
+    /**
+     * team 좋아요 취소
+     */
+    @ApiOperation(value ="팀 게시물 좋아요 취소")
+    @DeleteMapping("/team/unliking/{team_id}")
+    public ResponseTemplate<Boolean> cancelTeamLiking(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable(name = "team_id") Long teamId){
+        teamService.cancelTeamLiking(userDetails, teamId);
+        return ResponseTemplate.of(ResponseTemplateStatus.SUCCESS);
     }
 
     /**

--- a/src/main/java/com/projectmatching/app/domain/history/TeamHistoryRepository.java
+++ b/src/main/java/com/projectmatching/app/domain/history/TeamHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.projectmatching.app.domain.history;
+
+import com.projectmatching.app.domain.history.entity.TeamHistory;
+import com.projectmatching.app.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TeamHistoryRepository extends JpaRepository<TeamHistory, Long> {
+    List<TeamHistory> findTeamHistoriesByUser(User user);
+}

--- a/src/main/java/com/projectmatching/app/domain/history/entity/TeamHistory.java
+++ b/src/main/java/com/projectmatching/app/domain/history/entity/TeamHistory.java
@@ -1,0 +1,29 @@
+package com.projectmatching.app.domain.history.entity;
+
+import com.projectmatching.app.domain.user.entity.User;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@ToString
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@Builder
+@Table(name="team_history")
+public class TeamHistory {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user")
+    private User user;
+
+
+    //내가 조회한 팀의 아이디
+    private Long visited;
+}

--- a/src/main/java/com/projectmatching/app/domain/liking/repository/TeamLikingRepository.java
+++ b/src/main/java/com/projectmatching/app/domain/liking/repository/TeamLikingRepository.java
@@ -4,8 +4,12 @@ import com.projectmatching.app.domain.liking.entity.TeamLiking;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TeamLikingRepository extends JpaRepository<TeamLiking, Long> {
-    boolean existsByUser_IdAndTeam_Id(Long user_id, Long team_id);
-    void deleteByUser_IdAndTeam_Id(Long user_id, Long team_id);
+    boolean existsByUser_IdAndTeam_Id(Long userId, Long teamId);
+    void deleteByUser_IdAndTeam_Id(Long userId, Long teamId);
+
+    List<TeamLiking> findTeamLikingByUser_Id(Long userId);
 }

--- a/src/main/java/com/projectmatching/app/domain/liking/repository/TeamLikingRepository.java
+++ b/src/main/java/com/projectmatching/app/domain/liking/repository/TeamLikingRepository.java
@@ -5,11 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TeamLikingRepository extends JpaRepository<TeamLiking, Long> {
-    boolean existsByUser_IdAndTeam_Id(Long userId, Long teamId);
-    void deleteByUser_IdAndTeam_Id(Long userId, Long teamId);
-
+    Optional<TeamLiking> findByUser_IdAndTeam_Id(Long userId, Long teamId);
     List<TeamLiking> findTeamLikingByUser_Id(Long userId);
 }

--- a/src/main/java/com/projectmatching/app/domain/techStack/TechStackRepository.java
+++ b/src/main/java/com/projectmatching/app/domain/techStack/TechStackRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface TechStackRepository extends JpaRepository<TechStack, Long> {
     Optional<TechStack> findByName(String name);
+    Optional<TechStack> findByTechSerialNum(Long num);
 }

--- a/src/main/java/com/projectmatching/app/service/history/Impl/TeamHistoryServiceImpl.java
+++ b/src/main/java/com/projectmatching/app/service/history/Impl/TeamHistoryServiceImpl.java
@@ -1,0 +1,50 @@
+package com.projectmatching.app.service.history.Impl;
+
+import com.projectmatching.app.domain.history.TeamHistoryRepository;
+import com.projectmatching.app.domain.history.entity.TeamHistory;
+import com.projectmatching.app.domain.team.dto.TeamResponseDto;
+import com.projectmatching.app.domain.team.entity.Team;
+import com.projectmatching.app.domain.team.repository.TeamRepository;
+import com.projectmatching.app.domain.user.UserRepository;
+import com.projectmatching.app.domain.user.entity.User;
+import com.projectmatching.app.service.history.TeamHistoryService;
+import com.projectmatching.app.service.team.TeamService;
+import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
+import com.projectmatching.app.util.IdGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class TeamHistoryServiceImpl implements TeamHistoryService {
+
+    private final UserRepository userRepository;
+    private final TeamHistoryRepository teamHistoryRepository;
+    private final TeamRepository teamRepository;
+    private final TeamService teamService;
+
+    @Override
+    public Long savedTeamHistory(UserDetailsImpl userDetails, Long visitedTeamId) {
+        User user = userRepository.findByName(userDetails.getUserRealName()).orElseThrow(RuntimeException::new);
+        TeamHistory teamHistory = TeamHistory.builder()
+                .id(IdGenerator.number())
+                .visited(visitedTeamId)
+                .user(user)
+                .build();
+
+        return teamHistoryRepository.save(teamHistory).getId();
+    }
+
+    @Override
+    public List<TeamResponseDto> getTeamHistory(UserDetailsImpl userDetails) {
+        User user = userRepository.findByName(userDetails.getUserRealName()).orElseThrow(RuntimeException::new);
+
+        List<TeamHistory> teamHistories = teamHistoryRepository.findTeamHistoriesByUser(user);
+        List<Team> teams = teamHistories.stream().map(h -> teamRepository.findById(h.getVisited()).orElseThrow(NullPointerException::new)).collect(Collectors.toList());
+        return teamService.entityToDtoList(teams);
+    }
+}

--- a/src/main/java/com/projectmatching/app/service/history/TeamHistoryService.java
+++ b/src/main/java/com/projectmatching/app/service/history/TeamHistoryService.java
@@ -1,0 +1,14 @@
+package com.projectmatching.app.service.history;
+
+import com.projectmatching.app.domain.team.dto.TeamResponseDto;
+import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
+
+import java.util.List;
+
+public interface TeamHistoryService {
+    //팀 게시글 조회 이력 저장 서비스
+    Long savedTeamHistory(UserDetailsImpl userDetails, Long visitedTeamId);
+
+    //팀 게시글 조회 이력 열람 서비스
+    List<TeamResponseDto> getTeamHistory(UserDetailsImpl userDetails);
+}

--- a/src/main/java/com/projectmatching/app/service/team/TeamService.java
+++ b/src/main/java/com/projectmatching/app/service/team/TeamService.java
@@ -91,20 +91,7 @@ public class TeamService {
 
         try {
             List<Team> teams = teamRepository.getTeams(pageRequest);
-            List<TeamResponseDto> responseDto = new ArrayList<>();
-
-            for(Team team : teams){
-                TeamResponseDto teamResponseDto = new TeamResponseDto();
-                copyProperties(team, teamResponseDto);
-                teamResponseDto.setUser(findTeamUser(team));
-                teamResponseDto.setSkills(findTeamTech(team));
-                teamResponseDto.setCommentCnt(team.getTeamComments().size());
-                teamResponseDto.setLikeCnt(team.getTeamLikings().size());
-
-
-                responseDto.add(teamResponseDto);
-            }
-            return responseDto;
+            return entityToDtoList(teams);
 
         }catch (Exception e){
             throw new ResponeException(GET_TEAMS_ERROR);
@@ -128,26 +115,6 @@ public class TeamService {
             throw new ResponeException(GET_TEAM_ERROR);
         }
     }
-
-    public UserDto findTeamUser(Team team){
-        List<UserTeam> userTeamList = team.getUserTeams().stream().collect(Collectors.toList());
-        if(userTeamList.size() != 0) {
-            UserTeam findUser = userTeamList.get(0);
-            return UserDto.of(findUser.getUser());
-        }
-        else return null;
-    }
-
-    public List<String> findTeamTech(Team team){
-        Set<TeamTech> teamTechSet = team.getTeamTeches();
-        List<String> findTeamTech = new ArrayList<>();
-        for (TeamTech tech : teamTechSet){
-            TechStack t = tech.getTechStack();
-            if(t!=null) findTeamTech.add(t.getName());
-        }
-        return findTeamTech;
-    }
-
 
     //팀 게시글 삭제
     public void delete(Long teamId, String email) throws ResponeException {
@@ -190,15 +157,6 @@ public class TeamService {
         }
     }
 
-    public boolean checkTeamUser(Team team, User user){
-        List<UserTeam> userTeamList = team.getUserTeams().stream().collect(Collectors.toList());
-        boolean find = false;
-        for(UserTeam userTeam : userTeamList){
-            if(userTeam.getUser().getId() == user.getId()) find = true;
-        }
-        return find;
-    }
-
     //팀 좋아요 누르기
     public void doTeamLiking(UserDetailsImpl userDetails, Long teamId) throws ResponeException {
         try {
@@ -236,6 +194,11 @@ public class TeamService {
 
         List<TeamLiking> teamLikings = teamLikingRepository.findTeamLikingByUser_Id(user.getId());
         List<Team> teams = teamLikings.stream().map(t -> teamRepository.findById(t.getTeam().getId()).orElseThrow(RuntimeException::new)).collect(Collectors.toList());
+
+        return entityToDtoList(teams);
+    }
+
+    public List<TeamResponseDto> entityToDtoList(List<Team> teams){
         List<TeamResponseDto> responseDto = new ArrayList<>();
 
         for(Team team : teams){
@@ -248,5 +211,35 @@ public class TeamService {
             responseDto.add(teamResponseDto);
         }
         return responseDto;
+    }
+
+
+    public UserDto findTeamUser(Team team){
+        List<UserTeam> userTeamList = team.getUserTeams().stream().collect(Collectors.toList());
+        if(userTeamList.size() != 0) {
+            UserTeam findUser = userTeamList.get(0);
+            return UserDto.of(findUser.getUser());
+        }
+        else return null;
+    }
+
+    public List<String> findTeamTech(Team team){
+        Set<TeamTech> teamTechSet = team.getTeamTeches();
+        List<String> findTeamTech = new ArrayList<>();
+        for (TeamTech tech : teamTechSet){
+            TechStack t = tech.getTechStack();
+            if(t!=null) findTeamTech.add(t.getName());
+        }
+        return findTeamTech;
+    }
+
+
+    public boolean checkTeamUser(Team team, User user){
+        List<UserTeam> userTeamList = team.getUserTeams().stream().collect(Collectors.toList());
+        boolean find = false;
+        for(UserTeam userTeam : userTeamList){
+            if(userTeam.getUser().getId() == user.getId()) find = true;
+        }
+        return find;
     }
 }

--- a/src/main/java/com/projectmatching/app/service/team/TeamService.java
+++ b/src/main/java/com/projectmatching/app/service/team/TeamService.java
@@ -59,7 +59,7 @@ public class TeamService {
 
             List<Long> techs = requestDto.getSkills();
             for (Long t : techs){
-                TechStack techStack = techStackRepository.findById(t).orElseThrow(() -> new ResponeException(SAVE_TEAM_ERROR));
+                TechStack techStack = techStackRepository.findByTechSerialNum(t).orElseThrow(() -> new ResponeException(SAVE_TEAM_ERROR));
                 TeamTech teamTech = TeamTech.builder()
                         .team(team)
                         .techStack(techStack)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,12 +15,8 @@ spring:
 
   jpa:
     hibernate:
-<<<<<<< HEAD
       ddl-auto: create
-=======
-      ddl-auto: create-drop
 
->>>>>>> back
     properties:
       hibernate:
         # show_sql: true


### PR DESCRIPTION
### About

팀 게시물 좋아요&히스토리 관련 API 구현

### Description

- [x] : 팀 게시글 좋아요 등록 API 수정
- [x] : 팀 게시글 좋아요 취소 API 추가
- [x] : 내가 좋아요한 팀 목록 조회 API 추가
- [x] : 팀 게시글 히스토리 저장 API 추가
- [x] : 팀 게시글 히스토리 조회 API 추가

### Result

Postman 테스트 완료

### Ref

#57 #50 
