### PR TITLE
[FE] api 요청 url에 prefix 추가

### DIFF
--- a/webapp/src/api/auth.js
+++ b/webapp/src/api/auth.js
@@ -1,29 +1,29 @@
 import { API } from 'constant/api';
-import instance from './core';
+import rootApiInstance from './core';
 
 const authApi = {
   POST_LOGIN(data) {
-    return instance({
+    return rootApiInstance({
       url: API.AUTH.LOGIN,
       method: 'post',
       data,
     });
   },
   POST_SIGN_UP(data) {
-    return instance({
+    return rootApiInstance({
       url: API.AUTH.SIGNUP,
       method: 'post',
       data,
     });
   },
   GET_LOG_OUT() {
-    return instance({
+    return rootApiInstance({
       url: API.AUTH.LOGOUT,
       method: 'get',
     });
   },
   DEL_WITHDRAWAL() {
-    return instance({
+    return rootApiInstance({
       url: API.AUTH.WITHDRAWAL,
       method: 'delete',
     });

--- a/webapp/src/api/comment.js
+++ b/webapp/src/api/comment.js
@@ -1,61 +1,61 @@
 import { API } from 'constant/api';
-import instance from './core';
+import rootApiInstance from './core';
 
 const commentApi = {
   GET_COMMENT({ postType, postId }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}/${postId}`,
       method: 'get',
     });
   },
   POST_COMMENT({ postType, data }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}`,
       method: 'post',
       data,
     });
   },
   DELETE_COMMENT({ postType, id }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}/${id}`,
       method: 'delete',
     });
   },
   PATCH_COMMENT({ postType, id, data }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}/${id}`,
       method: 'patch',
       data,
     });
   },
   POST_REPLY({ postType, data }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.NESTED}`,
       method: 'post',
       data,
     });
   },
   DELETE_REPLY({ postType, id }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.NESTED}/${id}`,
       method: 'delete',
     });
   },
   PATCH_REPLY({ postType, id, data }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.NESTED}/${id}`,
       method: 'patch',
       data,
     });
   },
   PATCH_COMMENT_LIKE({ postType, id }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.LIKE}/${id}`,
       method: 'patch',
     });
   },
   PATCH_COMMENT_UN_LIKE({ postType, id }) {
-    return instance({
+    return rootApiInstance({
       url: `/${postType + API.COMMENT.UNLIKE}/${id}`,
       method: 'patch',
     });

--- a/webapp/src/api/core/index.js
+++ b/webapp/src/api/core/index.js
@@ -1,14 +1,14 @@
 import axios from 'axios';
-import { ROOT_URL } from 'constant/api';
+import { ROOT_API_URL } from 'constant/api';
 
-const instance = axios.create({
-  baseURL: ROOT_URL,
+const rootApiInstance = axios.create({
+  baseURL: ROOT_API_URL,
 });
 
-instance.defaults.timeout = 2500;
-instance.defaults.withCredentials = true;
+rootApiInstance.defaults.timeout = 2500;
+rootApiInstance.defaults.withCredentials = true;
 
-instance.interceptors.request.use(
+rootApiInstance.interceptors.request.use(
   (config) => {
     // 요청을 보내기 전에 수행할 로직
     config.headers['Content-Type'] = 'application/json; charset=utf-8';
@@ -21,7 +21,7 @@ instance.interceptors.request.use(
   },
 );
 
-instance.interceptors.response.use(
+rootApiInstance.interceptors.response.use(
   (response) => {
     // const {
     //   data: { code, data, message, status },
@@ -34,4 +34,4 @@ instance.interceptors.response.use(
   },
 );
 
-export default instance;
+export default rootApiInstance;

--- a/webapp/src/api/team.js
+++ b/webapp/src/api/team.js
@@ -1,41 +1,41 @@
 import { API } from 'constant/api';
-import instance from './core';
+import rootApiInstance from './core';
 
 const teamApi = {
   GET_TEAM_ARR(config) {
-    return instance({
+    return rootApiInstance({
       url: API.TEAM.LIST,
       method: 'get',
       ...config,
     });
   },
   GET_TEAM_DETAIL({ id }) {
-    return instance({
+    return rootApiInstance({
       url: `${API.TEAM.DETAIL}/${id}`,
       method: 'get',
     });
   },
   GET_TEAM_LIKES() {
-    return instance({
+    return rootApiInstance({
       url: API.TEAM.LIKES,
       method: 'get',
     });
   },
   GET_TEAM_READS() {
-    return instance({
+    return rootApiInstance({
       url: API.TEAM.READS,
       method: 'get',
     });
   },
   POST_TEAM_POST({ data }) {
-    return instance({
+    return rootApiInstance({
       url: API.TEAM.DETAIL,
       method: 'post',
       data,
     });
   },
   EDIT_TEAM_POST({ id, data }) {
-    return instance({
+    return rootApiInstance({
       url: `${API.TEAM.DETAIL}/${id}`,
       method: 'patch',
       data,

--- a/webapp/src/api/upload.js
+++ b/webapp/src/api/upload.js
@@ -1,8 +1,8 @@
-import instance from './core';
+import rootApiInstance from './core';
 
 const uploadApi = {
   IMAGE_UPLOAD(data) {
-    return instance({
+    return rootApiInstance({
       url: '/upload',
       method: 'post',
       data,

--- a/webapp/src/api/user.js
+++ b/webapp/src/api/user.js
@@ -1,40 +1,40 @@
 import { API } from 'constant/api';
-import instance from './core';
+import rootApiInstance from './core';
 
 const userApi = {
   GET_USER_LIST(config) {
-    return instance({
+    return rootApiInstance({
       url: API.USER.LIST,
       method: 'get',
       ...config,
     });
   },
   GET_USER_DETAIL({ id }) {
-    return instance({
+    return rootApiInstance({
       url: `${API.USER.DETAIL}/${id}`,
       method: 'get',
     });
   },
   GET_USER_LIKES() {
-    return instance({
+    return rootApiInstance({
       url: API.USER.LIKES,
       method: 'get',
     });
   },
   GET_USER_READS() {
-    return instance({
+    return rootApiInstance({
       url: API.USER.READS,
       method: 'get',
     });
   },
   GET_MY_POSTS() {
-    return instance({
+    return rootApiInstance({
       url: API.USER.MYPOSTS,
       method: 'get',
     });
   },
   EDIT_USER_PROFILE({ data }) {
-    return instance({
+    return rootApiInstance({
       url: API.USER.PROFILE,
       method: 'patch',
       data,

--- a/webapp/src/constant/api.js
+++ b/webapp/src/constant/api.js
@@ -1,5 +1,5 @@
 export const API_PREFIX = '/api';
-export const ROOT_URL = process.env.REACT_APP_SERVER_API + API_PREFIX;
+export const ROOT_API_URL = process.env.REACT_APP_SERVER_API + API_PREFIX;
 
 export const API = {
   AUTH: {

--- a/webapp/src/constant/api.js
+++ b/webapp/src/constant/api.js
@@ -1,6 +1,5 @@
-export const ROOT_URL = process.env.REACT_APP_SERVER_API;
-
-export const MOCK_SERVER_URL = process.env.REACT_APP_MOCK_SERVER_API;
+export const API_PREFIX = '/api';
+export const ROOT_URL = process.env.REACT_APP_SERVER_API + API_PREFIX;
 
 export const API = {
   AUTH: {

--- a/webapp/src/mocks/auth/index.js
+++ b/webapp/src/mocks/auth/index.js
@@ -1,19 +1,19 @@
-import { API, ROOT_URL } from 'constant/api';
+import { API, ROOT_API_URL } from 'constant/api';
 import { getResonseWithData, successResponseWithEmptyData } from 'mocks/mockUtils';
 import { rest } from 'msw';
 import { mockMyData } from './mockMyData';
 
 const AUTH = [
-  rest.post(ROOT_URL + API.AUTH.LOGIN, (req, res, ctx) => {
+  rest.post(ROOT_API_URL + API.AUTH.LOGIN, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(getResonseWithData(mockMyData)));
   }),
-  rest.post(ROOT_URL + API.AUTH.SIGNUP, (req, res, ctx) => {
+  rest.post(ROOT_API_URL + API.AUTH.SIGNUP, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
-  rest.get(ROOT_URL + API.AUTH.LOGOUT, (req, res, ctx) => {
+  rest.get(ROOT_API_URL + API.AUTH.LOGOUT, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
-  rest.delete(ROOT_URL + API.AUTH.WITHDRAWAL, (req, res, ctx) => {
+  rest.delete(ROOT_API_URL + API.AUTH.WITHDRAWAL, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
 ];

--- a/webapp/src/mocks/comment/index.js
+++ b/webapp/src/mocks/comment/index.js
@@ -1,4 +1,4 @@
-import { API, ROOT_URL } from 'constant/api';
+import { API, ROOT_API_URL } from 'constant/api';
 import { getResonseWithData, successResponseWithEmptyData } from 'mocks/mockUtils';
 import { rest } from 'msw';
 import { teamComments } from './teamComments';
@@ -7,92 +7,92 @@ import { userComments } from './userComments';
 const COMMENT = [
   // ------------ USER ------------
   // GET_USER_COMMENT
-  rest.get(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
     console.log('request GET_USER_COMMENT');
     return res(ctx.status(200), ctx.json(getResonseWithData(userComments)));
   }),
   // POST_USER_COMMENT
-  rest.post(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}`, (req, res, ctx) => {
+  rest.post(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}`, (req, res, ctx) => {
     console.log('request POST_USER_COMMENT');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // DELETE_USER_COMMENT
-  rest.delete(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
+  rest.delete(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
     console.log('request DELETE_USER_COMMENT');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_USER_COMMENT
-  rest.patch(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
     console.log('request PATCH_USER_COMMENT');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // POST_USER_REPLY
-  rest.post(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
+  rest.post(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
     console.log('request POST_USER_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // DELETE_USER_REPLY
-  rest.delete(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
+  rest.delete(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
     console.log('request DELETE_USER_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_USER_REPLY
-  rest.patch(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
     console.log('request PATCH_USER_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_USER_COMMENT_LIKE
-  rest.patch(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.LIKE}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.LIKE}/:id`, (req, res, ctx) => {
     console.log('request PATCH_USER_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_USER_COMMENT_UN_LIKE
-  rest.patch(`${ROOT_URL + API.USER.DETAIL + API.COMMENT.UNLIKE}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.USER.DETAIL + API.COMMENT.UNLIKE}/:id`, (req, res, ctx) => {
     console.log('request PATCH_USER_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // ------------ TEAM ------------
   // GET_TEAM_COMMENT
-  rest.get(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(getResonseWithData(teamComments)));
   }),
   // POST_TEAM_COMMENT
-  rest.post(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}`, (req, res, ctx) => {
+  rest.post(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}`, (req, res, ctx) => {
     console.log('request POST_TEAM_COMMENT');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // DELETE_TEAM_COMMENT
-  rest.delete(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
+  rest.delete(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
     console.log('request DELETE_TEAM_COMMENT');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_TEAM_COMMENT
-  rest.patch(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.ORIGIN}/:id`, (req, res, ctx) => {
     console.log('request PATCH_TEAM_COMMENT');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // POST_TEAM_REPLY
-  rest.post(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.NESTED}`, (req, res, ctx) => {
+  rest.post(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.NESTED}`, (req, res, ctx) => {
     console.log('request POST_TEAM_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // DELETE_TEAM_REPLY
-  rest.delete(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
+  rest.delete(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
     console.log('request DELETE_TEAM_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_TEAM_REPLY
-  rest.patch(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.NESTED}/:id`, (req, res, ctx) => {
     console.log('request PATCH_TEAM_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_TEAM_COMMENT_LIKE
-  rest.patch(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.LIKE}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.LIKE}/:id`, (req, res, ctx) => {
     console.log('request PATCH_TEAM_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),
   // PATCH_TEAM_COMMENT_UN_LIKE
-  rest.patch(`${ROOT_URL + API.TEAM.DETAIL + API.COMMENT.UNLIKE}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.TEAM.DETAIL + API.COMMENT.UNLIKE}/:id`, (req, res, ctx) => {
     console.log('request PATCH_TEAM_REPLY');
     return res(ctx.status(200), ctx.json(successResponseWithEmptyData));
   }),

--- a/webapp/src/mocks/team/index.js
+++ b/webapp/src/mocks/team/index.js
@@ -1,4 +1,4 @@
-import { API, ROOT_URL } from 'constant/api';
+import { API, ROOT_API_URL } from 'constant/api';
 import { getRandomStatusErrorCode, getResonseWithData } from 'mocks/mockUtils';
 import { rest } from 'msw';
 import { editTeamDetail } from './editTeamDetail';
@@ -7,13 +7,13 @@ import { teamsList } from './teamsList';
 
 const TEAM = [
   // GET_TEAM_ARR
-  rest.get(ROOT_URL + API.TEAM.LIST, (req, res, ctx) => {
+  rest.get(ROOT_API_URL + API.TEAM.LIST, (req, res, ctx) => {
     const lastPage = req.url.searchParams.get('lastPage');
     const newTeamList = teamsList.map((team) => ({ ...team, id: Number(team.id + lastPage) }));
     return res(ctx.status(200), ctx.delay(1500), ctx.json(getResonseWithData(newTeamList)));
   }),
   // GET_TEAM_LIKES
-  rest.get(`${ROOT_URL + API.TEAM.LIKES}`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL + API.TEAM.LIKES}`, (req, res, ctx) => {
     const randomStatusErrorCode = getRandomStatusErrorCode();
     return res(
       ctx.status(randomStatusErrorCode),
@@ -22,7 +22,7 @@ const TEAM = [
     );
   }),
   // GET_TEAM_READS
-  rest.get(`${ROOT_URL + API.TEAM.READS}`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL + API.TEAM.READS}`, (req, res, ctx) => {
     const randomStatusErrorCode = getRandomStatusErrorCode();
     return res(
       ctx.status(randomStatusErrorCode),
@@ -31,17 +31,17 @@ const TEAM = [
     );
   }),
   // GET_TEAM_DETAIL
-  rest.get(`${ROOT_URL + API.TEAM.DETAIL}/:id`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL + API.TEAM.DETAIL}/:id`, (req, res, ctx) => {
     const randomStatusErrorCode = getRandomStatusErrorCode();
     return res(ctx.status(randomStatusErrorCode), ctx.json(getResonseWithData(teamDetail)));
   }),
   // POST_TEAM_POST
-  rest.post(`${ROOT_URL + API.TEAM.DETAIL}`, (req, res, ctx) => {
+  rest.post(`${ROOT_API_URL + API.TEAM.DETAIL}`, (req, res, ctx) => {
     console.log(req.body);
     return res(ctx.status(200), ctx.json(getResonseWithData(teamDetail)));
   }),
   // EDIT_TEAM_POST
-  rest.patch(`${ROOT_URL + API.TEAM.DETAIL}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.TEAM.DETAIL}/:id`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(getResonseWithData(editTeamDetail)));
   }),
 ];

--- a/webapp/src/mocks/user/index.js
+++ b/webapp/src/mocks/user/index.js
@@ -1,4 +1,4 @@
-import { API, ROOT_URL } from 'constant/api';
+import { API, ROOT_API_URL } from 'constant/api';
 import { rest } from 'msw';
 import { getResonseWithData, getRandomStatusErrorCode } from 'mocks/mockUtils';
 import { userList } from './usersList';
@@ -7,7 +7,7 @@ import { userDetail } from './userDetail';
 
 const USER = [
   // GET_USER_LIST
-  rest.get(ROOT_URL + API.USER.LIST, (req, res, ctx) => {
+  rest.get(ROOT_API_URL + API.USER.LIST, (req, res, ctx) => {
     const lastPage = req.url.searchParams.get('lastPage');
     const newUserList = userList.map((user) => ({ ...user, id: Number(user.id + lastPage) }));
     if (Number(lastPage) === 3) {
@@ -16,7 +16,7 @@ const USER = [
     return res(ctx.status(200), ctx.json(getResonseWithData(newUserList)));
   }),
   // GET_USER_LIKES
-  rest.get(ROOT_URL + API.USER.LIKES, (req, res, ctx) => {
+  rest.get(ROOT_API_URL + API.USER.LIKES, (req, res, ctx) => {
     const randomStatusErrorCode = getRandomStatusErrorCode();
     return res(
       ctx.status(randomStatusErrorCode),
@@ -25,7 +25,7 @@ const USER = [
     );
   }),
   // GET_USER_READS
-  rest.get(ROOT_URL + API.USER.READS, (req, res, ctx) => {
+  rest.get(ROOT_API_URL + API.USER.READS, (req, res, ctx) => {
     const randomStatusErrorCode = getRandomStatusErrorCode();
     return res(
       ctx.status(randomStatusErrorCode),
@@ -34,7 +34,7 @@ const USER = [
     );
   }),
   // GET_MY_POSTS
-  rest.get(ROOT_URL + API.USER.MYPOSTS, (req, res, ctx) => {
+  rest.get(ROOT_API_URL + API.USER.MYPOSTS, (req, res, ctx) => {
     const randomStatusErrorCode = getRandomStatusErrorCode();
     return res(
       ctx.status(randomStatusErrorCode),
@@ -43,12 +43,12 @@ const USER = [
     );
   }),
   // GET_USER_DETAIL
-  rest.get(`${ROOT_URL + API.USER.DETAIL}/:id`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL + API.USER.DETAIL}/:id`, (req, res, ctx) => {
     const randomStatusErrorCode = getRandomStatusErrorCode();
     return res(ctx.status(randomStatusErrorCode), ctx.json(getResonseWithData(userDetail)));
   }),
   // EDIT_USER_PROFILE
-  rest.patch(`${ROOT_URL + API.USER.DETAIL}/:id`, (req, res, ctx) => {
+  rest.patch(`${ROOT_API_URL + API.USER.DETAIL}/:id`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(getResonseWithData(userDetail)));
   }),
 ];


### PR DESCRIPTION
# About

서버 배포환경에 따라 브라우저에서 페이지를 구별하는 url과 api요청 url을 구분하는 prefix 추가

# Description

### 1. 서버 api 마다 prefix로 `/api`추가

### 2. api instance 네이밍 변경

instance라는 네이밍이 광범위하고 모호해서 다음과 같이 변경

```
instance -> rootApiInstance
```

# Ref

#99 
