### PR TITLE
Fix: user entity readCnt 수정

### DIFF
--- a/src/main/java/com/projectmatching/app/domain/user/entity/User.java
+++ b/src/main/java/com/projectmatching/app/domain/user/entity/User.java
@@ -61,8 +61,8 @@ public class User extends BaseTimeEntity  {
     @Column(columnDefinition = "INT")
     private int respected;
 
-    @Column(columnDefinition = "BIGINT")
-    private int read;
+    @Column(name = "read_cnt",columnDefinition = "BIGINT")
+    private int readCnt;
     /**
      * 내가 좋아요한 유저 목록
      */


### PR DESCRIPTION
# About

회원가입이 안되는 오류 수정

# Description

User Entity의 조회수를 저장하는 read 칼럼의 이름이 문제가되어 insert 쿼리를 제대로 날리지 못하는 것으로 보임
따라서 조회수 칼럼 이름을 read_cnt로 수정 



# Result
제대로 저장되는 것을 확인함

# Ref


