### PR TITLE
유저 필수정보 입력 로직 수정 및 최초 로그인 유저 체크 로직 추가

### DIFF
--- a/src/main/generated/com/projectmatching/app/domain/team/entity/QTeamTech.java
+++ b/src/main/generated/com/projectmatching/app/domain/team/entity/QTeamTech.java
@@ -34,7 +34,7 @@ public class QTeamTech extends EntityPathBase<TeamTech> {
 
     public final QTeam team;
 
-    public final com.projectmatching.app.domain.techStack.entity.QTechStack techStack;
+    public final com.projectmatching.app.domain.techStack.entity.QTechCode techStack;
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
@@ -58,7 +58,7 @@ public class QTeamTech extends EntityPathBase<TeamTech> {
     public QTeamTech(Class<? extends TeamTech> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.team = inits.isInitialized("team") ? new QTeam(forProperty("team")) : null;
-        this.techStack = inits.isInitialized("techStack") ? new com.projectmatching.app.domain.techStack.entity.QTechStack(forProperty("techStack")) : null;
+        this.techStack = inits.isInitialized("techStack") ? new com.projectmatching.app.domain.techStack.entity.QTechCode(forProperty("techStack")) : null;
     }
 
 }

--- a/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechCode.java
+++ b/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechCode.java
@@ -19,11 +19,26 @@ public class QTechCode extends EntityPathBase<TechCode> {
 
     public static final QTechCode techCode = new QTechCode("techCode");
 
+    public final com.projectmatching.app.domain.QBaseTimeEntity _super = new com.projectmatching.app.domain.QBaseTimeEntity(this);
+
+    public final StringPath category = createString("category");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
     public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath image = createString("image");
 
     public final NumberPath<Integer> key = createNumber("key", Integer.class);
 
-    public final StringPath value = createString("value");
+    //inherited
+    public final StringPath status = _super.status;
+
+    public final StringPath techName = createString("techName");
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
     public QTechCode(String variable) {
         super(TechCode.class, forVariable(variable));

--- a/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechStack.java
+++ b/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechStack.java
@@ -22,15 +22,15 @@ public class QTechStack extends EntityPathBase<TechStack> {
 
     public final StringPath category = createString("category");
 
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> key = createNumber("key", Long.class);
+
     public final StringPath name = createString("name");
 
     public final SetPath<com.projectmatching.app.domain.team.entity.TeamTech, com.projectmatching.app.domain.team.entity.QTeamTech> teamTechs = this.<com.projectmatching.app.domain.team.entity.TeamTech, com.projectmatching.app.domain.team.entity.QTeamTech>createSet("teamTechs", com.projectmatching.app.domain.team.entity.TeamTech.class, com.projectmatching.app.domain.team.entity.QTeamTech.class, PathInits.DIRECT2);
 
-    public final NumberPath<Long> techSerialNum = createNumber("techSerialNum", Long.class);
-
-    public final NumberPath<Long> techStackId = createNumber("techStackId", Long.class);
-
-    public final SetPath<com.projectmatching.app.domain.user.entity.UserTech, com.projectmatching.app.domain.user.entity.QUserTech> userTeches = this.<com.projectmatching.app.domain.user.entity.UserTech, com.projectmatching.app.domain.user.entity.QUserTech>createSet("userTeches", com.projectmatching.app.domain.user.entity.UserTech.class, com.projectmatching.app.domain.user.entity.QUserTech.class, PathInits.DIRECT2);
+    public final SetPath<com.projectmatching.app.domain.user.entity.UserTech, com.projectmatching.app.domain.user.entity.QUserTech> userTechs = this.<com.projectmatching.app.domain.user.entity.UserTech, com.projectmatching.app.domain.user.entity.QUserTech>createSet("userTechs", com.projectmatching.app.domain.user.entity.UserTech.class, com.projectmatching.app.domain.user.entity.QUserTech.class, PathInits.DIRECT2);
 
     public QTechStack(String variable) {
         super(TechStack.class, forVariable(variable));

--- a/src/main/generated/com/projectmatching/app/domain/user/entity/QUser.java
+++ b/src/main/generated/com/projectmatching/app/domain/user/entity/QUser.java
@@ -33,7 +33,9 @@ public class QUser extends EntityPathBase<User> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final StringPath img = createString("img");
+    public final StringPath image = createString("image");
+
+    public final BooleanPath isTeamExist = createBoolean("isTeamExist");
 
     public final StringPath job = createString("job");
 
@@ -45,7 +47,7 @@ public class QUser extends EntityPathBase<User> {
 
     public final StringPath pwd = createString("pwd");
 
-    public final NumberPath<Integer> read = createNumber("read", Integer.class);
+    public final NumberPath<Integer> readCnt = createNumber("readCnt", Integer.class);
 
     public final NumberPath<Integer> respected = createNumber("respected", Integer.class);
 

--- a/src/main/java/com/projectmatching/app/controller/user/UserEditController.java
+++ b/src/main/java/com/projectmatching/app/controller/user/UserEditController.java
@@ -32,8 +32,8 @@ public class UserEditController {
      */
     @ApiOperation(value = "유저 필수정보 업데이트 ")
     @PostMapping("/essential_info")
-    public ResponseTemplate<Void> updateEssential(@RequestBody UserEssentialDto userEssentialDto){
-        userSignUpService.updateUserEssentialInfo(userEssentialDto);
+    public ResponseTemplate<Void> updateEssential(@RequestBody UserEssentialDto userEssentialDto, @AuthenticationPrincipal UserDetailsImpl userDetails){
+        userSignUpService.updateUserEssentialInfo(userEssentialDto,userDetails);
         return ResponseTemplate.of(SUCCESS);
     }
 

--- a/src/main/java/com/projectmatching/app/controller/user/UserSignController.java
+++ b/src/main/java/com/projectmatching/app/controller/user/UserSignController.java
@@ -2,11 +2,13 @@ package com.projectmatching.app.controller.user;
 
 import com.projectmatching.app.config.resTemplate.ResponeException;
 import com.projectmatching.app.config.resTemplate.ResponseTemplate;
+import com.projectmatching.app.domain.user.dto.UserIsFirstDto;
 import com.projectmatching.app.domain.user.dto.UserJoinDto;
 import com.projectmatching.app.domain.user.dto.UserLoginDto;
 import com.projectmatching.app.service.user.Impl.UserService;
 import com.projectmatching.app.service.user.Impl.UserSignInService;
 import com.projectmatching.app.service.user.Impl.UserSignUpService;
+import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
 import com.projectmatching.app.util.AuthToken;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -17,7 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletResponse;
+
 
 import static com.projectmatching.app.constant.ResponseTemplateStatus.SUCCESS;
 
@@ -43,13 +45,15 @@ public class UserSignController {
     /**
      * 로그인
      */
-    @ApiOperation(value = "일반 로그인, 성공시 유저 id 반환 및 헤더에 토큰 생성")
+    @ApiOperation(value = "일반 로그인, 성공시 유저 id 반환 및 헤더에 토큰 생성, 최초 로그인 여부가 isFirst 이름으로 전달됨")
     @PostMapping("/login")
-    public ResponseEntity<ResponseTemplate<Void>> login(@RequestBody UserLoginDto userLoginDto, HttpServletResponse response) {
-        AuthToken authToken = userSignInService.userLogin(userLoginDto,response);
+    public ResponseEntity<ResponseTemplate<UserIsFirstDto>> login(@RequestBody UserLoginDto userLoginDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        AuthToken authToken = userSignInService.userLogin(userLoginDto);
         return ResponseEntity.ok()
                 .headers(HttpHeaders.readOnlyHttpHeaders(authToken.asHeaders()))
-                .body(ResponseTemplate.of(SUCCESS));
+                .body(ResponseTemplate.valueOf(
+                        userSignInService.isFirstLoginUserCheck(userDetails)
+                ));
     }
 
 

--- a/src/main/java/com/projectmatching/app/domain/user/QUserRepository.java
+++ b/src/main/java/com/projectmatching/app/domain/user/QUserRepository.java
@@ -76,4 +76,5 @@ public class QUserRepository {
 
 
 
+
 }

--- a/src/main/java/com/projectmatching/app/domain/user/dto/UserEssentialDto.java
+++ b/src/main/java/com/projectmatching/app/domain/user/dto/UserEssentialDto.java
@@ -27,7 +27,6 @@ import static com.projectmatching.app.constant.ServiceConstant.NAME_SIZE_MAX;
  */
 public class UserEssentialDto implements Validatable {
 
-    private Long id;
     private String name;
     private String slogan;
     private String image;
@@ -36,7 +35,6 @@ public class UserEssentialDto implements Validatable {
     private List<Integer> skills; //기술 스택 key 값만 받음
     private String hope_session; //원하는2 작업기간
     private String job; //직업
-    private Boolean status; //팀 소속 여부
 
 
     @Override

--- a/src/main/java/com/projectmatching/app/domain/user/dto/UserIsFirstDto.java
+++ b/src/main/java/com/projectmatching/app/domain/user/dto/UserIsFirstDto.java
@@ -1,0 +1,14 @@
+package com.projectmatching.app.domain.user.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserIsFirstDto {
+
+    Boolean isFirst;
+
+}

--- a/src/main/java/com/projectmatching/app/domain/user/dto/UserLoginResDto.java
+++ b/src/main/java/com/projectmatching/app/domain/user/dto/UserLoginResDto.java
@@ -8,6 +8,7 @@ import lombok.*;
 /**
  * 오직 로그인시에 반환되는 DTO
  */
+@Deprecated
 @Getter @Setter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/projectmatching/app/domain/user/entity/User.java
+++ b/src/main/java/com/projectmatching/app/domain/user/entity/User.java
@@ -144,7 +144,6 @@ public class User extends BaseTimeEntity  {
                     TechCode.toUserTechWithAddedUser(t,this)
                 ).collect(Collectors.toSet());
         this.portfolio = userEssentialDto.getPortfolio();
-        this.isTeamExist = userEssentialDto.getStatus();
         this.hope_session = userEssentialDto.getHope_session();
 
         return this;

--- a/src/main/java/com/projectmatching/app/service/user/Impl/UserSignInService.java
+++ b/src/main/java/com/projectmatching/app/service/user/Impl/UserSignInService.java
@@ -65,15 +65,15 @@ public class UserSignInService {
     public UserIsFirstDto isFirstLoginUserCheck(UserDetailsImpl userDetails){
         User user = userRepository.findByEmail(userDetails.getEmail()).orElseThrow(CoNectNotFoundException::new);
 
-        if(isUserNameNull(user))UserIsFirstDto.builder().isFirst(true).build();
+        if(isUserNameNull(user)) return UserIsFirstDto.builder().isFirst(true).build();
 
         return UserIsFirstDto.builder().isFirst(false).build();
 
     }
 
     private boolean isUserNameNull(User user){
-        if(user.getName() != null)return false;
-        else return true;
+        if(user.getName() == null)return true;
+        else return false;
 
     }
 

--- a/src/main/java/com/projectmatching/app/service/user/Impl/UserSignUpService.java
+++ b/src/main/java/com/projectmatching/app/service/user/Impl/UserSignUpService.java
@@ -10,6 +10,7 @@ import com.projectmatching.app.domain.user.dto.UserEssentialDto;
 import com.projectmatching.app.domain.user.dto.UserJoinDto;
 import com.projectmatching.app.domain.user.entity.User;
 import com.projectmatching.app.exception.CoNectNotFoundException;
+import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -46,9 +47,9 @@ public class UserSignUpService {
 
     @Transactional
     @Validation
-    public void updateUserEssentialInfo(UserEssentialDto userEssentialDto){
+    public void updateUserEssentialInfo(UserEssentialDto userEssentialDto, UserDetailsImpl userDetails){
         checkDuplicateName(userEssentialDto.getName());
-        User user = userRepository.findById(userEssentialDto.getId()).orElseThrow(CoNectNotFoundException::new);
+        User user = userRepository.findById(userDetails.getUserId()).orElseThrow(CoNectNotFoundException::new);
         userRepository.save(user.updateEssentialInfo(userEssentialDto,techStackProvider));
 
     }

--- a/src/test/java/com/projectmatching/app/service/user/UserIsFisrtLoginTest.java
+++ b/src/test/java/com/projectmatching/app/service/user/UserIsFisrtLoginTest.java
@@ -1,0 +1,67 @@
+package com.projectmatching.app.service.user;
+
+import com.projectmatching.app.domain.user.UserRepository;
+import com.projectmatching.app.domain.user.dto.UserIsFirstDto;
+import com.projectmatching.app.domain.user.entity.User;
+import com.projectmatching.app.service.ServiceTest;
+import com.projectmatching.app.service.user.Impl.UserSignInService;
+import com.projectmatching.app.service.user.Impl.UserSignUpService;
+import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class UserIsFisrtLoginTest extends ServiceTest {
+
+
+    @InjectMocks
+    private UserSignInService userSignInService;
+
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserDetailsImpl userDetails;
+
+    @Test
+    @DisplayName("최초 로그인 유저인 경우 UserIsFirst 값 true로 전달")
+    void GIVEN_NULL_NICKNAME_USER_THEN_RETURN_ISFIRST_LOGIN_TRUE_DTO(){
+        User user = User.builder()
+                .email("yesman@naver.com")
+                .pwd("!@#!#5682348248692381!@#8536jaxdhas")
+                .build();
+
+
+
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+        when(userDetails.getEmail()).thenReturn("yesman@naver.com");
+        UserIsFirstDto result = userSignInService.isFirstLoginUserCheck(userDetails);
+
+        Assertions.assertTrue(result.getIsFirst());
+    }
+
+    @Test
+    @DisplayName("최초 로그인 유저가 아닌 경우 UserIsFirst 값 false로 전달")
+    void GIVEN_NOT_NULL_NICKNAME_USER_THEN_RETURN_ISFIRST_LOGIN_FALSE_DTO(){
+                User user = User.builder()
+                .email("yesman@naver.com")
+                        .name("yesman")
+                .pwd("!@#!#5682348248692381!@#8536jaxdhas")
+                .build();
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
+        when(userDetails.getEmail()).thenReturn("yesman@naver.com");
+        UserIsFirstDto result = userSignInService.isFirstLoginUserCheck(userDetails);
+
+        Assertions.assertFalse(result.getIsFirst());
+    }
+}

--- a/src/test/java/com/projectmatching/app/service/user/UserSignUpServiceTest.java
+++ b/src/test/java/com/projectmatching/app/service/user/UserSignUpServiceTest.java
@@ -9,6 +9,7 @@ import com.projectmatching.app.domain.user.dto.UserJoinDto;
 import com.projectmatching.app.domain.user.entity.User;
 import com.projectmatching.app.service.ServiceTest;
 import com.projectmatching.app.service.user.Impl.UserSignUpService;
+import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +39,9 @@ public class UserSignUpServiceTest extends ServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserDetailsImpl userDetails;
 
     private UserJoinDto userJoinDto;
     private UserEssentialDto userEssentialDto;
@@ -93,17 +97,16 @@ public class UserSignUpServiceTest extends ServiceTest {
                 .slogan("slogan")
                 .image("img")
                 .job("무직")
-                .email("123@naver.com")
                 .hope_session("1개월")
                 .build();
 
         User user = mock(User.class);
         when(user.updateEssentialInfo(userEssentialDto,techStackProvider)).thenReturn(user);
-        when(userRepository.findByName(anyString())).thenReturn(Optional.empty()); //중복되는 이름을 갖는 유저 없음
-        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user)); // 해당 유저의 필수정보를 업데이트함
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
         when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userDetails.getUserId()).thenReturn(anyLong());
 
-        userSignUpService.updateUserEssentialInfo(userEssentialDto);
+        userSignUpService.updateUserEssentialInfo(userEssentialDto,userDetails);
 
     }
 
@@ -117,15 +120,13 @@ public class UserSignUpServiceTest extends ServiceTest {
                 .slogan("slogan")
                 .image("img")
                 .job("무직")
-                .email("123@naver.com")
                 .hope_session("1개월")
                 .build();
 
         User user = mock(User.class);
-        when(userRepository.findByName(anyString())).thenReturn(Optional.of(user)); //중복되는 이름을 갖는 유저 없음
-
+        when(userRepository.findByName(anyString())).thenReturn(Optional.of(user)); //중복되는 이름을 갖는 유저
         assertThrows(ResponeException.class,()->{
-            userSignUpService.updateUserEssentialInfo(userEssentialDto);
+            userSignUpService.updateUserEssentialInfo(userEssentialDto,userDetails);
         });
     }
 


### PR DESCRIPTION
# About
- 유저 필수 정보 입력시 id 값 입력 받지 않고,  토큰 값을 이용해 해당 유저 필수정보를 업데이트 하도록 수정
- 로그인 하는 경우 최초 로그인 유저인지 체크하여 isFirst 값을 전달함
- 필수 정보 입력시 팀 소속 여부는 받지 않도록 수정함



# Result

최초 로그인 반환 테스트 성공 

<img width="357" alt="스크린샷 2022-08-09 오전 1 40 17" src="https://user-images.githubusercontent.com/48795102/183469142-277acef6-89c8-4db4-800a-5b595c36ce9e.png">



