### PR TITLE
[FE] 로그인 이후 acess token 및 refresh token localstorage에 저장

### DIFF
--- a/webapp/src/api/auth.js
+++ b/webapp/src/api/auth.js
@@ -1,36 +1,24 @@
 import { API } from 'constant/api';
-import rootApiInstance from './core/rootApiInstance';
+import authApiInstance from './core/authApiInstance';
 
 const authApi = {
   POST_LOGIN(data) {
-    return rootApiInstance({
+    console.log('authApi', data);
+    return authApiInstance({
       url: API.AUTH.LOGIN,
       method: 'post',
       data,
     });
   },
-  POST_ESSENTIAL_INFO(data) {
-    return rootApiInstance({
-      url: API.AUTH.ESSENTIAL_INFO,
-      method: 'post',
-      data,
-    });
-  },
-  GET_ESSENTIAL_INFO() {
-    return rootApiInstance({
-      url: API.AUTH.ESSENTIAL_INFO,
-      method: 'get',
-    });
-  },
   POST_SIGN_UP(data) {
-    return rootApiInstance({
+    return authApiInstance({
       url: API.AUTH.SIGNUP,
       method: 'post',
       data,
     });
   },
   DEL_WITHDRAWAL() {
-    return rootApiInstance({
+    return authApiInstance({
       url: API.AUTH.WITHDRAWAL,
       method: 'delete',
     });

--- a/webapp/src/api/auth.js
+++ b/webapp/src/api/auth.js
@@ -3,7 +3,6 @@ import authApiInstance from './core/authApiInstance';
 
 const authApi = {
   POST_LOGIN(data) {
-    console.log('authApi', data);
     return authApiInstance({
       url: API.AUTH.LOGIN,
       method: 'post',

--- a/webapp/src/api/auth.js
+++ b/webapp/src/api/auth.js
@@ -1,23 +1,23 @@
 import { API } from 'constant/api';
-import authApiInstance from './core/authApiInstance';
+import publicApiInstance from './core/publicApiInstance';
 
 const authApi = {
   POST_LOGIN(data) {
-    return authApiInstance({
+    return publicApiInstance({
       url: API.AUTH.LOGIN,
       method: 'post',
       data,
     });
   },
   POST_SIGN_UP(data) {
-    return authApiInstance({
+    return publicApiInstance({
       url: API.AUTH.SIGNUP,
       method: 'post',
       data,
     });
   },
   DEL_WITHDRAWAL() {
-    return authApiInstance({
+    return publicApiInstance({
       url: API.AUTH.WITHDRAWAL,
       method: 'delete',
     });

--- a/webapp/src/api/comment.js
+++ b/webapp/src/api/comment.js
@@ -1,61 +1,62 @@
 import { API } from 'constant/api';
-import rootApiInstance from './core/rootApiInstance';
+import privateApiInstance from './core/privateApiInstance';
+import publicApiInstance from './core/publicApiInstance';
 
 const commentApi = {
   GET_COMMENT({ postType, postId }) {
-    return rootApiInstance({
+    return publicApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}/${postId}`,
       method: 'get',
     });
   },
   POST_COMMENT({ postType, data }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}`,
       method: 'post',
       data,
     });
   },
   DELETE_COMMENT({ postType, id }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}/${id}`,
       method: 'delete',
     });
   },
   PATCH_COMMENT({ postType, id, data }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.ORIGIN}/${id}`,
       method: 'patch',
       data,
     });
   },
   POST_REPLY({ postType, data }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.NESTED}`,
       method: 'post',
       data,
     });
   },
   DELETE_REPLY({ postType, id }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.NESTED}/${id}`,
       method: 'delete',
     });
   },
   PATCH_REPLY({ postType, id, data }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.NESTED}/${id}`,
       method: 'patch',
       data,
     });
   },
   PATCH_COMMENT_LIKE({ postType, id }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.LIKE}/${id}`,
       method: 'patch',
     });
   },
   PATCH_COMMENT_UN_LIKE({ postType, id }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `/${postType + API.COMMENT.UNLIKE}/${id}`,
       method: 'patch',
     });

--- a/webapp/src/api/core/authApiInstance.js
+++ b/webapp/src/api/core/authApiInstance.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { ROOT_API_URL } from 'constant/api';
+import { successHandler, errorHandler } from './responseHandler';
+
+const authApiInstance = axios.create({
+  baseURL: ROOT_API_URL,
+});
+
+authApiInstance.defaults.timeout = 2500;
+
+authApiInstance.interceptors.request.use(
+  (config) => {
+    return config;
+  },
+  (error) => {
+    // 요청 에러가 발생했을 때 수행할 로직
+    console.log(error); // 디버깅
+    return error;
+  },
+);
+
+authApiInstance.interceptors.response.use(successHandler, errorHandler);
+
+export default authApiInstance;

--- a/webapp/src/api/core/privateApiInstance.js
+++ b/webapp/src/api/core/privateApiInstance.js
@@ -11,15 +11,24 @@ const privateApiInstance = axios.create({
 privateApiInstance.defaults.timeout = 2500;
 // privateApiInstance.defaults.withCredentials = true;
 
+const setAcessTokenInRequestConfig = (config) => {
+  const accessToken = handleToken.getAccessToken();
+  const refreshToken = handleToken.getRefreshToken();
+  // 요청을 보내기 전에 수행할 로직
+
+  if (!config?.headers || !accessToken || !refreshToken) {
+    return config;
+  }
+  config.headers.Authorization = `Bearer ${accessToken}`;
+  config.headers[TOKEN.REFRESH] = refreshToken;
+  return config;
+};
+
 privateApiInstance.interceptors.request.use(
   (config) => {
-    const accessToken = handleToken.getAccessToken();
-    const refreshToken = handleToken.getRefreshToken();
-    // 요청을 보내기 전에 수행할 로직
     config.headers['Content-Type'] = 'application/json; charset=utf-8';
-    config.headers.Authorization = `Bearer ${accessToken}`;
-    config.headers[TOKEN.REFRESH] = refreshToken;
-    return config;
+    const newConfig = setAcessTokenInRequestConfig(config);
+    return newConfig;
   },
   (error) => {
     // 요청 에러가 발생했을 때 수행할 로직

--- a/webapp/src/api/core/privateApiInstance.js
+++ b/webapp/src/api/core/privateApiInstance.js
@@ -4,14 +4,14 @@ import { handleToken } from 'service/auth';
 
 import { successHandler, errorHandler } from './responseHandler';
 
-const rootApiInstance = axios.create({
+const privateApiInstance = axios.create({
   baseURL: ROOT_API_URL,
 });
 
-rootApiInstance.defaults.timeout = 2500;
-// rootApiInstance.defaults.withCredentials = true;
+privateApiInstance.defaults.timeout = 2500;
+// privateApiInstance.defaults.withCredentials = true;
 
-rootApiInstance.interceptors.request.use(
+privateApiInstance.interceptors.request.use(
   (config) => {
     const accessToken = handleToken.getAccessToken();
     const refreshToken = handleToken.getRefreshToken();
@@ -28,6 +28,6 @@ rootApiInstance.interceptors.request.use(
   },
 );
 
-rootApiInstance.interceptors.response.use(successHandler, errorHandler);
+privateApiInstance.interceptors.response.use(successHandler, errorHandler);
 
-export default rootApiInstance;
+export default privateApiInstance;

--- a/webapp/src/api/core/publicApiInstance.js
+++ b/webapp/src/api/core/publicApiInstance.js
@@ -2,13 +2,13 @@ import axios from 'axios';
 import { ROOT_API_URL } from 'constant/api';
 import { successHandler, errorHandler } from './responseHandler';
 
-const authApiInstance = axios.create({
+const publicApiInstance = axios.create({
   baseURL: ROOT_API_URL,
 });
 
-authApiInstance.defaults.timeout = 2500;
+publicApiInstance.defaults.timeout = 2500;
 
-authApiInstance.interceptors.request.use(
+publicApiInstance.interceptors.request.use(
   (config) => {
     return config;
   },
@@ -19,6 +19,6 @@ authApiInstance.interceptors.request.use(
   },
 );
 
-authApiInstance.interceptors.response.use(successHandler, errorHandler);
+publicApiInstance.interceptors.response.use(successHandler, errorHandler);
 
-export default authApiInstance;
+export default publicApiInstance;

--- a/webapp/src/api/core/responseHandler.js
+++ b/webapp/src/api/core/responseHandler.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-prototype-builtins */
 
 export function successHandler(response) {
-  const { data } = response;
-  return data;
+  const { data, headers } = response;
+  return { ...data, headers };
 }
 
 export function errorHandler(error) {

--- a/webapp/src/api/core/rootApiInstance.js
+++ b/webapp/src/api/core/rootApiInstance.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { ROOT_API_URL, ACCESS_TOKEN, REFRESH_TOKEN } from 'constant/api';
+import { ROOT_API_URL, TOKEN } from 'constant/api';
 import handleLocalstorage from 'utils/handleLocalstorage';
 import { successHandler, errorHandler } from './responseHandler';
 
@@ -12,12 +12,12 @@ rootApiInstance.defaults.timeout = 2500;
 
 rootApiInstance.interceptors.request.use(
   (config) => {
-    const accessToken = handleLocalstorage.get(ACCESS_TOKEN);
-    const refreshToken = handleLocalstorage.get(REFRESH_TOKEN);
+    const accessToken = handleLocalstorage.get(TOKEN.ACCESS);
+    const refreshToken = handleLocalstorage.get(TOKEN.REFRESH);
     // 요청을 보내기 전에 수행할 로직
     config.headers['Content-Type'] = 'application/json; charset=utf-8';
-    // config.headers.Authorization = `Bearer ${accessToken}`;
-    // config.headers['x-refresh-token'] = refreshToken;
+    config.headers.Authorization = `Bearer ${accessToken}`;
+    config.headers[TOKEN.REFRESH] = refreshToken;
     return config;
   },
   (error) => {

--- a/webapp/src/api/core/rootApiInstance.js
+++ b/webapp/src/api/core/rootApiInstance.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { ROOT_API_URL, TOKEN } from 'constant/api';
-import handleLocalstorage from 'utils/handleLocalstorage';
+import { handleToken } from 'service/auth';
+
 import { successHandler, errorHandler } from './responseHandler';
 
 const rootApiInstance = axios.create({
@@ -12,8 +13,8 @@ rootApiInstance.defaults.timeout = 2500;
 
 rootApiInstance.interceptors.request.use(
   (config) => {
-    const accessToken = handleLocalstorage.get(TOKEN.ACCESS);
-    const refreshToken = handleLocalstorage.get(TOKEN.REFRESH);
+    const accessToken = handleToken.getAccessToken();
+    const refreshToken = handleToken.getRefreshToken();
     // 요청을 보내기 전에 수행할 로직
     config.headers['Content-Type'] = 'application/json; charset=utf-8';
     config.headers.Authorization = `Bearer ${accessToken}`;

--- a/webapp/src/api/core/rootApiInstance.js
+++ b/webapp/src/api/core/rootApiInstance.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
-import { ROOT_API_URL } from 'constant/api';
+import { ROOT_API_URL, ACCESS_TOKEN, REFRESH_TOKEN } from 'constant/api';
+import handleLocalstorage from 'utils/handleLocalstorage';
 import { successHandler, errorHandler } from './responseHandler';
 
 const rootApiInstance = axios.create({
@@ -11,8 +12,12 @@ rootApiInstance.defaults.timeout = 2500;
 
 rootApiInstance.interceptors.request.use(
   (config) => {
+    const accessToken = handleLocalstorage.get(ACCESS_TOKEN);
+    const refreshToken = handleLocalstorage.get(REFRESH_TOKEN);
     // 요청을 보내기 전에 수행할 로직
     config.headers['Content-Type'] = 'application/json; charset=utf-8';
+    // config.headers.Authorization = `Bearer ${accessToken}`;
+    // config.headers['x-refresh-token'] = refreshToken;
     return config;
   },
   (error) => {

--- a/webapp/src/api/team.js
+++ b/webapp/src/api/team.js
@@ -1,41 +1,42 @@
 import { API } from 'constant/api';
-import rootApiInstance from './core/rootApiInstance';
+import privateApiInstance from './core/privateApiInstance';
+import publicApiInstance from './core/publicApiInstance';
 
 const teamApi = {
   GET_TEAM_ARR(config) {
-    return rootApiInstance({
+    return publicApiInstance({
       url: API.TEAM.INDEX,
       method: 'get',
       ...config,
     });
   },
   GET_TEAM_DETAIL({ id }) {
-    return rootApiInstance({
+    return publicApiInstance({
       url: `${API.TEAM.INDEX}/${id}`,
       method: 'get',
     });
   },
   GET_TEAM_LIKES() {
-    return rootApiInstance({
+    return publicApiInstance({
       url: API.TEAM.LIKES,
       method: 'get',
     });
   },
   GET_TEAM_READS() {
-    return rootApiInstance({
+    return publicApiInstance({
       url: API.TEAM.READS,
       method: 'get',
     });
   },
   POST_TEAM_POST({ data }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: API.TEAM.INDEX,
       method: 'post',
       data,
     });
   },
   EDIT_TEAM_POST({ id, data }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: `${API.TEAM.INDEX}/${id}`,
       method: 'patch',
       data,

--- a/webapp/src/api/upload.js
+++ b/webapp/src/api/upload.js
@@ -1,8 +1,8 @@
-import rootApiInstance from './core/rootApiInstance';
+import privateApiInstance from './core/privateApiInstance';
 
 const uploadApi = {
   IMAGE_UPLOAD(data) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: '/upload',
       method: 'post',
       data,

--- a/webapp/src/api/user.js
+++ b/webapp/src/api/user.js
@@ -1,53 +1,54 @@
 import { API } from 'constant/api';
-import rootApiInstance from './core/rootApiInstance';
+import privateApiInstance from './core/privateApiInstance';
+import publicApiInstance from './core/publicApiInstance';
 
 const userApi = {
   POST_ESSENTIAL_INFO(data) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: API.AUTH.ESSENTIAL_INFO,
       method: 'post',
       data,
     });
   },
   GET_ESSENTIAL_INFO() {
-    return rootApiInstance({
+    return privateApiInstance({
       url: API.AUTH.ESSENTIAL_INFO,
       method: 'get',
     });
   },
   GET_USER_LIST(config) {
-    return rootApiInstance({
+    return publicApiInstance({
       url: API.USER.INDEX,
       method: 'get',
       ...config,
     });
   },
   GET_USER_DETAIL({ id }) {
-    return rootApiInstance({
+    return publicApiInstance({
       url: `${API.USER.INDEX}/${id}`,
       method: 'get',
     });
   },
   GET_USER_LIKES() {
-    return rootApiInstance({
+    return publicApiInstance({
       url: API.USER.LIKES,
       method: 'get',
     });
   },
   GET_USER_READS() {
-    return rootApiInstance({
+    return publicApiInstance({
       url: API.USER.READS,
       method: 'get',
     });
   },
   GET_MY_POSTS() {
-    return rootApiInstance({
+    return publicApiInstance({
       url: API.USER.MYPOSTS,
       method: 'get',
     });
   },
   EDIT_USER_PROFILE({ data }) {
-    return rootApiInstance({
+    return privateApiInstance({
       url: API.USER.PROFILE,
       method: 'patch',
       data,

--- a/webapp/src/api/user.js
+++ b/webapp/src/api/user.js
@@ -2,6 +2,19 @@ import { API } from 'constant/api';
 import rootApiInstance from './core/rootApiInstance';
 
 const userApi = {
+  POST_ESSENTIAL_INFO(data) {
+    return rootApiInstance({
+      url: API.AUTH.ESSENTIAL_INFO,
+      method: 'post',
+      data,
+    });
+  },
+  GET_ESSENTIAL_INFO() {
+    return rootApiInstance({
+      url: API.AUTH.ESSENTIAL_INFO,
+      method: 'get',
+    });
+  },
   GET_USER_LIST(config) {
     return rootApiInstance({
       url: API.USER.INDEX,

--- a/webapp/src/components/ToastNotification/index.jsx
+++ b/webapp/src/components/ToastNotification/index.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
-import checkIcon from 'assets/check.svg';
-import errorIcon from 'assets/error.svg';
-import infoIcon from 'assets/info.svg';
-import warningIcon from 'assets/warning.svg';
+import checkIcon from 'assets/icons/check.svg';
+import errorIcon from 'assets/icons/error.svg';
+import infoIcon from 'assets/icons/info.svg';
+import warningIcon from 'assets/icons/warning.svg';
 import * as S from './style';
 
 ToastNotification.propTypes = {

--- a/webapp/src/constant/api.js
+++ b/webapp/src/constant/api.js
@@ -1,5 +1,5 @@
 export const TOKEN = {
-  ACCESS: 'acessToken',
+  ACCESS: 'authorization',
   REFRESH: 'x-refresh-token',
 };
 

--- a/webapp/src/constant/api.js
+++ b/webapp/src/constant/api.js
@@ -1,5 +1,7 @@
-export const ACCESS_TOKEN = 'accessToken';
-export const REFRESH_TOKEN = 'refreshToken';
+export const TOKEN = {
+  ACCESS: 'acessToken',
+  REFRESH: 'x-refresh-token',
+};
 
 export const API_PREFIX = '/api';
 export const ROOT_API_URL = process.env.REACT_APP_SERVER_API + API_PREFIX;

--- a/webapp/src/constant/api.js
+++ b/webapp/src/constant/api.js
@@ -1,3 +1,6 @@
+export const ACCESS_TOKEN = 'accessToken';
+export const REFRESH_TOKEN = 'refreshToken';
+
 export const API_PREFIX = '/api';
 export const ROOT_API_URL = process.env.REACT_APP_SERVER_API + API_PREFIX;
 

--- a/webapp/src/mocks/auth/index.js
+++ b/webapp/src/mocks/auth/index.js
@@ -1,11 +1,20 @@
-import { API, ROOT_API_URL } from 'constant/api';
+import { API, ROOT_API_URL, TOKEN } from 'constant/api';
 import { getResonseWithData, successResponseWithEmptyData } from 'mocks/mockUtils';
 import { rest } from 'msw';
 import { mockLoginData, mockEssentialInfo, mockSignUpData } from './mockMyData';
 
 const AUTH = [
   rest.post(ROOT_API_URL + API.AUTH.LOGIN, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(getResonseWithData(mockLoginData)));
+    return res(
+      ctx.status(200),
+      ctx.set({
+        [TOKEN.ACCESS]:
+          'eyJhbGciOiJIUzI1NiJ9.YXNkZkBhc2RmYXNkZi5jb20.h-oLZnV0pCeNKa_AM3ilQzerD2Uj7bKUn1xDft5DzOk',
+        [TOKEN.REFRESH]:
+          'eyJhbGciOiJIUzI1NiJ9.YXNkZkBhc2RmYXNkZi5jb20.h-oLZnV0pCeNKa_AM3ilQzerD2Uj7bKUn1xDft5DzOk',
+      }),
+      ctx.json(getResonseWithData(mockLoginData)),
+    );
   }),
   rest.post(ROOT_API_URL + API.AUTH.SIGNUP, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(getResonseWithData(mockSignUpData)));

--- a/webapp/src/mocks/auth/mockMyData.js
+++ b/webapp/src/mocks/auth/mockMyData.js
@@ -1,6 +1,5 @@
 export const mockLoginData = {
-  email: '92719@naver.com',
-  pwd: '12345',
+  isFirstLogin: true,
 };
 export const mockSignUpData = {
   email: '92719@naver.com',

--- a/webapp/src/mocks/auth/mockMyData.js
+++ b/webapp/src/mocks/auth/mockMyData.js
@@ -1,5 +1,5 @@
 export const mockLoginData = {
-  isFirstLogin: true,
+  isFirst: true,
 };
 export const mockSignUpData = {
   email: '92719@naver.com',

--- a/webapp/src/mocks/mockMyData.js
+++ b/webapp/src/mocks/mockMyData.js
@@ -1,9 +1,0 @@
-const myData = {
-  data: {
-    user_id: '927191821029312',
-    nickname: '코넥트',
-    img: 'https://user-images.githubusercontent.com/71386219/157435570-a48382a8-63e5-4d25-91f4-e506289424b5.png',
-  },
-};
-
-export default myData;

--- a/webapp/src/pages/Login/index.jsx
+++ b/webapp/src/pages/Login/index.jsx
@@ -2,11 +2,14 @@ import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { OAUTH_URL } from 'constant/route';
-import { updateUserInfo } from 'service/auth';
 import authApi from 'api/auth';
+import { notifyNewMessage } from 'contexts/ToastNotification/action';
+import { useToastNotificationAction } from 'contexts/ToastNotification';
+import { TOAST_TYPE } from 'contexts/ToastNotification/type';
 import * as S from './style';
 
 export default function Login() {
+  const notifyDispatch = useToastNotificationAction();
   const navigate = useNavigate();
   const {
     register,
@@ -18,7 +21,6 @@ export default function Login() {
   const [apiError, setApiError] = useState({ isError: false, msg: '' });
   const onValid = async (submitData) => {
     const { email, password } = submitData;
-
     try {
       const response = await authApi.POST_LOGIN({ email, pwd: password });
       console.log(response);
@@ -27,6 +29,7 @@ export default function Login() {
       // TODO: 성공시 이동할 페이지 정해서 이동시키기
     } catch (apiError) {
       console.error(apiError);
+      notifyNewMessage(notifyDispatch, apiError, TOAST_TYPE.Error);
       setApiError({
         isError: true,
         msg: apiError,

--- a/webapp/src/pages/Login/index.jsx
+++ b/webapp/src/pages/Login/index.jsx
@@ -26,11 +26,11 @@ export default function Login() {
       const response = await authApi.POST_LOGIN({ email, pwd: password });
       const {
         headers,
-        data: { isFirstLogin },
+        data: { isFirst: isFirstLogin },
       } = response;
       handleToken.saveAccessToken(headers[TOKEN.ACCESS]);
       handleToken.saveRefreshToken(headers[TOKEN.REFRESH]);
-
+      notifyNewMessage(notifyDispatch, '로그인이 성공적으로 완료되었습니다.', TOAST_TYPE.Success);
       if (isFirstLogin) navigate('/essential_info');
     } catch (apiError) {
       console.error(apiError);

--- a/webapp/src/pages/Login/index.jsx
+++ b/webapp/src/pages/Login/index.jsx
@@ -6,6 +6,8 @@ import authApi from 'api/auth';
 import { notifyNewMessage } from 'contexts/ToastNotification/action';
 import { useToastNotificationAction } from 'contexts/ToastNotification';
 import { TOAST_TYPE } from 'contexts/ToastNotification/type';
+import { handleToken } from 'service/auth';
+import { TOKEN } from 'constant/api';
 import * as S from './style';
 
 export default function Login() {
@@ -18,22 +20,21 @@ export default function Login() {
   } = useForm({
     defaultValues: {},
   });
-  const [apiError, setApiError] = useState({ isError: false, msg: '' });
   const onValid = async (submitData) => {
     const { email, password } = submitData;
     try {
       const response = await authApi.POST_LOGIN({ email, pwd: password });
-      console.log(response);
-      // 최초 로그인인지 아닌지
-      navigate('/essential_info');
-      // TODO: 성공시 이동할 페이지 정해서 이동시키기
+      const {
+        headers,
+        data: { isFirstLogin },
+      } = response;
+      handleToken.saveAccessToken(headers[TOKEN.ACCESS]);
+      handleToken.saveRefreshToken(headers[TOKEN.REFRESH]);
+
+      if (isFirstLogin) navigate('/essential_info');
     } catch (apiError) {
       console.error(apiError);
       notifyNewMessage(notifyDispatch, apiError, TOAST_TYPE.Error);
-      setApiError({
-        isError: true,
-        msg: apiError,
-      });
     }
   };
 

--- a/webapp/src/service/auth.js
+++ b/webapp/src/service/auth.js
@@ -1,18 +1,34 @@
 import { USER_INFO } from 'constant';
-import storage from 'utils/handleLocalstorage';
+import { TOKEN } from 'constant/api';
+import handleLocalstorage from 'utils/handleLocalstorage';
 
 export const updateUserInfo = (rawUserInfo) => {
   const userInfo = changeUserInfoKey(rawUserInfo);
-  storage.set(USER_INFO, userInfo);
+  handleLocalstorage.set(USER_INFO, userInfo);
 };
 
-export const deleteUserInfo = () => storage.remove(USER_INFO);
+export const deleteUserInfo = () => handleLocalstorage.remove(USER_INFO);
 
-export const getUserInfo = () => storage.get(USER_INFO);
+export const getUserInfo = () => handleLocalstorage.get(USER_INFO);
 
 export const isLogin = () => getUserInfo();
 
 export const changeUserInfoKey = (userInfo) => {
   const { user_id, image, nickname } = userInfo;
   return { userId: user_id, image, name: nickname };
+};
+
+export const handleToken = {
+  getAccessToken() {
+    return handleLocalstorage.get(TOKEN.ACCESS);
+  },
+  saveAccessToken(tokenValue) {
+    handleLocalstorage.set(TOKEN.ACCESS, tokenValue);
+  },
+  getRefreshToken() {
+    return handleLocalstorage.get(TOKEN.REFRESH);
+  },
+  saveRefreshToken(tokenValue) {
+    handleLocalstorage.set(TOKEN.REFRESH, tokenValue);
+  },
 };

--- a/webapp/src/service/auth.js
+++ b/webapp/src/service/auth.js
@@ -1,5 +1,5 @@
 import { USER_INFO } from 'constant';
-import storage from 'utils/localstorage';
+import storage from 'utils/handleLocalstorage';
 
 export const updateUserInfo = (rawUserInfo) => {
   const userInfo = changeUserInfoKey(rawUserInfo);

--- a/webapp/src/utils/handleLocalstorage.js
+++ b/webapp/src/utils/handleLocalstorage.js
@@ -1,4 +1,4 @@
-const storage = {
+const handleLocalstorage = {
   set: (key, object) => {
     if (!localStorage) return;
     localStorage[key] = typeof object === 'string' ? object : JSON.stringify(object);
@@ -27,4 +27,4 @@ const storage = {
   },
 };
 
-export default storage;
+export default handleLocalstorage;


### PR DESCRIPTION
# About

1. 로그인 이후 acess token 및 refresh token localstorage에 저장
2. privateApiInstance와 publicApiInstance를 구분해서 privateApiInstance요청일 때만 header에 토큰 담아주기

# Description

## 1. 로그인 이후 acess token 및 refresh token localstorage에 저장

`src/service/auth.js`에 handlerToken 생성

- getAccessToken : 로컬 스토리지에 있는 access token가져오기
- saveAccessToken : 로컬 스토리지에 access token 저장하기
- getRefreshToken : 로컬 스토리지에 있는 refresh token가져오기
- saveRefreshToken : 로컬 스토리지에 refresh token 저장하기


## 2. privateApiInstance와 authApi를 구분해서 privateApiInstance요청일 때만 header에 토큰 담아주기

- privateApiInstance: `인증`이  필요한 api 인스턴스
- publicApiInstance: 회원가입, 로그인 및 get요청에 관련된 api인스턴스

```jsx
// src/api/privateApiInstance.js
// privateApiInstance헤더에 토큰 넣는 로직
const setAcessTokenInRequestConfig = (config) => {
  const accessToken = handleToken.getAccessToken();
  const refreshToken = handleToken.getRefreshToken();
  // 요청을 보내기 전에 수행할 로직

  if (!config?.headers || !accessToken || !refreshToken) {
    return config;
  }
  config.headers.Authorization = `Bearer ${accessToken}`;
  config.headers[TOKEN.REFRESH] = refreshToken;
  return config;
};
```