### PR TITLE
유저 조회수 업데이트 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
 
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     testImplementation 'io.rest-assured:rest-assured:3.3.0'
     testImplementation 'org.mockito:mockito-inline:3.6.0'

--- a/src/main/java/com/projectmatching/app/DemoApplication.java
+++ b/src/main/java/com/projectmatching/app/DemoApplication.java
@@ -1,44 +1,24 @@
 package com.projectmatching.app;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.projectmatching.app.constant.TechStackConstant;
-import com.projectmatching.app.constant.bean.TechStackCodeBean;
-import com.projectmatching.app.domain.cache.CacheType;
-import com.projectmatching.app.domain.cache.readCount.ReadCount;
-import io.swagger.annotations.ApiOperation;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
+
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.caffeine.CaffeineCache;
-import org.springframework.cache.support.SimpleCacheManager;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
+
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
-//teset
 @EnableJpaAuditing
 @EnableSwagger2
 @EnableCaching
+@EnableAsync
 @SpringBootApplication
 public class DemoApplication {
 
-
-    static private ReadCount readCount;
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);
-
-
     }
-
-
 
 }

--- a/src/main/java/com/projectmatching/app/DemoApplication.java
+++ b/src/main/java/com/projectmatching/app/DemoApplication.java
@@ -1,23 +1,38 @@
 package com.projectmatching.app;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.projectmatching.app.constant.TechStackConstant;
 import com.projectmatching.app.constant.bean.TechStackCodeBean;
+import com.projectmatching.app.domain.cache.CacheType;
+import com.projectmatching.app.domain.cache.readCount.ReadCount;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 //teset
 @EnableJpaAuditing
 @EnableSwagger2
+@EnableCaching
 @SpringBootApplication
 public class DemoApplication {
 
 
+    static private ReadCount readCount;
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class, args);
 

--- a/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
+++ b/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
@@ -12,6 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static com.projectmatching.app.constant.ServiceConstant.*;
 import static com.projectmatching.app.util.InMemoryUtil.readCntMap;
 
@@ -30,6 +33,8 @@ public class UserReadCntUpdateHandler {
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateUserReadCnt(User user){
+        log.info("Updating User Read Cnt Logic === ");
+
         AddUserReadCntInfoToMap(user); //유저 조회수 정보를 임시 저장함
 
         if(readCntMap.size() == MAX_USER_READ_CNT_SIZE){
@@ -38,8 +43,8 @@ public class UserReadCntUpdateHandler {
                 //조회수 업데이트
                 User forUpdatedUser = userRepository.findById(aLong).orElseThrow(CoNectLogicalException::new);
                 forUpdatedUser.updatingReadCnt(readCntMap.get(aLong));
-
                 userRepository.save(forUpdatedUser);
+
             }
             readCntMap.clear();
         }

--- a/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
+++ b/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
@@ -4,14 +4,19 @@ import com.projectmatching.app.domain.user.UserRepository;
 import com.projectmatching.app.domain.user.entity.User;
 import com.projectmatching.app.exception.CoNectLogicalException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import static com.projectmatching.app.constant.ServiceConstant.*;
 import static com.projectmatching.app.util.InMemoryUtil.readCntMap;
 
 @RequiredArgsConstructor
+@Slf4j
 @Component
 public class UserReadCntUpdateHandler {
     private final UserRepository userRepository;
@@ -22,28 +27,27 @@ public class UserReadCntUpdateHandler {
      * 파라미터로 받은 유저 카드를 조회할때 해당 유저의 조회 정보를 따로 캐싱하여 저장함
      * @param user
      */
-    @Async
     @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateUserReadCnt(User user){
+        AddUserReadCntInfoToMap(user); //유저 조회수 정보를 임시 저장함
 
         if(readCntMap.size() == MAX_USER_READ_CNT_SIZE){
-
+            log.info("Updating User Read Cnt : Triggered by MAX_USER_READ_CNT_SIZE");
             for (Long aLong : readCntMap.keySet()) {
                 //조회수 업데이트
                 User forUpdatedUser = userRepository.findById(aLong).orElseThrow(CoNectLogicalException::new);
                 forUpdatedUser.updatingReadCnt(readCntMap.get(aLong));
 
+                userRepository.save(forUpdatedUser);
             }
             readCntMap.clear();
+        }
 
-            AddUserReadCntInfoToMap(user);
-        }else
-            AddUserReadCntInfoToMap(user); //유저 조회수 정보를 임시 저장함
 
     }
 
     private void AddUserReadCntInfoToMap(User user){
         readCntMap.compute(user.getId(),(key,val) -> (val == null) ? 1 : val + 1); //처음 조회된 유저라면 1로 삽입 , 아니라면  조회수 +1 해서 메모리에 임시 저장
-
     }
 }

--- a/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
+++ b/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
@@ -1,0 +1,49 @@
+package com.projectmatching.app.config.handler;
+
+import com.projectmatching.app.domain.user.UserRepository;
+import com.projectmatching.app.domain.user.entity.User;
+import com.projectmatching.app.exception.CoNectLogicalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static com.projectmatching.app.constant.ServiceConstant.*;
+import static com.projectmatching.app.util.InMemoryUtil.readCntMap;
+
+@RequiredArgsConstructor
+@Component
+public class UserReadCntUpdateHandler {
+    private final UserRepository userRepository;
+
+
+    /**
+     *
+     * 파라미터로 받은 유저 카드를 조회할때 해당 유저의 조회 정보를 따로 캐싱하여 저장함
+     * @param user
+     */
+    @Async
+    @TransactionalEventListener
+    public void updateUserReadCnt(User user){
+
+        if(readCntMap.size() == MAX_USER_READ_CNT_SIZE){
+
+            for (Long aLong : readCntMap.keySet()) {
+                //조회수 업데이트
+                User forUpdatedUser = userRepository.findById(aLong).orElseThrow(CoNectLogicalException::new);
+                forUpdatedUser.updatingReadCnt(readCntMap.get(aLong));
+
+            }
+            readCntMap.clear();
+
+            AddUserReadCntInfoToMap(user);
+        }else
+            AddUserReadCntInfoToMap(user); //유저 조회수 정보를 임시 저장함
+
+    }
+
+    private void AddUserReadCntInfoToMap(User user){
+        readCntMap.compute(user.getId(),(key,val) -> (val == null) ? 1 : val + 1); //처음 조회된 유저라면 1로 삽입 , 아니라면  조회수 +1 해서 메모리에 임시 저장
+
+    }
+}

--- a/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
+++ b/src/main/java/com/projectmatching/app/config/handler/UserReadCntUpdateHandler.java
@@ -33,8 +33,6 @@ public class UserReadCntUpdateHandler {
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateUserReadCnt(User user){
-        log.info("Updating User Read Cnt Logic === ");
-
         AddUserReadCntInfoToMap(user); //유저 조회수 정보를 임시 저장함
 
         if(readCntMap.size() == MAX_USER_READ_CNT_SIZE){

--- a/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
+++ b/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
@@ -8,6 +8,6 @@ public class ServiceConstant {
     public static final Pattern REGEX_PWD = Pattern.compile("(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&+=])(?=\\S+$).{8,20}"); //8자 이상 20자 이하, 숫자 한개이상 특수문자 한개이상 포함 공백 불가
     public static final int NAME_SIZE_MAX = 20;
 
-    public static final int MAX_USER_READ_CNT_SIZE = 50;
+    public static final int MAX_USER_READ_CNT_SIZE = 10;
 
 }

--- a/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
+++ b/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
@@ -8,4 +8,6 @@ public class ServiceConstant {
     public static final Pattern REGEX_PWD = Pattern.compile("(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&+=])(?=\\S+$).{8,20}"); //8자 이상 20자 이하, 숫자 한개이상 특수문자 한개이상 포함 공백 불가
     public static final int NAME_SIZE_MAX = 20;
 
+    public static final int MAX_USER_READ_CNT_SIZE = 50;
+
 }

--- a/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
+++ b/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
@@ -8,6 +8,6 @@ public class ServiceConstant {
     public static final Pattern REGEX_PWD = Pattern.compile("(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&+=])(?=\\S+$).{8,20}"); //8자 이상 20자 이하, 숫자 한개이상 특수문자 한개이상 포함 공백 불가
     public static final int NAME_SIZE_MAX = 20;
 
-    public static final int MAX_USER_READ_CNT_SIZE = 2;
+    public static final int MAX_USER_READ_CNT_SIZE = 10; //유저 조회수 업데이트 기준, MAX_USER_READ_CNT_SIZE 명의 유저 조회수 업데이트를 함
 
 }

--- a/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
+++ b/src/main/java/com/projectmatching/app/constant/ServiceConstant.java
@@ -8,6 +8,6 @@ public class ServiceConstant {
     public static final Pattern REGEX_PWD = Pattern.compile("(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&+=])(?=\\S+$).{8,20}"); //8자 이상 20자 이하, 숫자 한개이상 특수문자 한개이상 포함 공백 불가
     public static final int NAME_SIZE_MAX = 20;
 
-    public static final int MAX_USER_READ_CNT_SIZE = 10;
+    public static final int MAX_USER_READ_CNT_SIZE = 2;
 
 }

--- a/src/main/java/com/projectmatching/app/domain/cache/CacheConfig.java
+++ b/src/main/java/com/projectmatching/app/domain/cache/CacheConfig.java
@@ -1,0 +1,43 @@
+package com.projectmatching.app.domain.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.projectmatching.app.domain.cache.readCount.ReadCount;
+import com.projectmatching.app.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class CacheConfig {
+
+    private final UserRepository userRepository;
+
+    @Bean
+    public CacheManager cacheManager() {
+        List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                .map(cache -> new CaffeineCache(cache.getCacheName(), Caffeine.newBuilder().recordStats()
+                                .maximumSize(cache.getMaximumSize())
+                                .build()
+                        )
+                )
+                .collect(Collectors.toList());
+
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caches);
+
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/projectmatching/app/domain/cache/CacheConfig.java
+++ b/src/main/java/com/projectmatching/app/domain/cache/CacheConfig.java
@@ -1,7 +1,6 @@
 package com.projectmatching.app.domain.cache;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.projectmatching.app.domain.cache.readCount.ReadCount;
 import com.projectmatching.app.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/projectmatching/app/domain/cache/CacheType.java
+++ b/src/main/java/com/projectmatching/app/domain/cache/CacheType.java
@@ -1,0 +1,24 @@
+package com.projectmatching.app.domain.cache;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+
+    TECH_CODE(
+            "techCode",
+            60*60*5, //만료시간 5시간
+            100 //100개 사이즈
+    );
+
+
+
+
+    private final String cacheName;
+    private final int expireAfterWrite;
+    private final int maximumSize;
+
+
+}

--- a/src/main/java/com/projectmatching/app/domain/cache/ReadCnt.java
+++ b/src/main/java/com/projectmatching/app/domain/cache/ReadCnt.java
@@ -1,0 +1,14 @@
+package com.projectmatching.app.domain.cache;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReadCnt {
+
+    private Long id; //유저 및 팀 id
+    private Integer count; //조회수 카운팅
+}

--- a/src/main/java/com/projectmatching/app/domain/user/entity/User.java
+++ b/src/main/java/com/projectmatching/app/domain/user/entity/User.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 public class User extends BaseTimeEntity  {
 
     @Id
-    @GeneratedValue
     private Long id;
 
 

--- a/src/main/java/com/projectmatching/app/domain/user/entity/User.java
+++ b/src/main/java/com/projectmatching/app/domain/user/entity/User.java
@@ -154,7 +154,7 @@ public class User extends BaseTimeEntity  {
      * @Param plusCount : 증가할 조회수
      */
     public void updatingReadCnt(int plusCount){
-        this.readCnt = this.readCnt + plusCount;
+        this.readCnt += plusCount;
 
     }
 

--- a/src/main/java/com/projectmatching/app/domain/user/entity/User.java
+++ b/src/main/java/com/projectmatching/app/domain/user/entity/User.java
@@ -149,6 +149,15 @@ public class User extends BaseTimeEntity  {
         return this;
     }
 
+    /**
+     * plusCount 만큼 조회수 증가
+     * @Param plusCount : 증가할 조회수
+     */
+    public void updatingReadCnt(int plusCount){
+        this.readCnt = this.readCnt + plusCount;
+
+    }
+
 
 
 

--- a/src/main/java/com/projectmatching/app/exception/CoNectLogicalException.java
+++ b/src/main/java/com/projectmatching/app/exception/CoNectLogicalException.java
@@ -1,0 +1,11 @@
+package com.projectmatching.app.exception;
+
+import com.projectmatching.app.constant.ResponseTemplateStatus;
+
+public class CoNectLogicalException extends CoNectRuntimeException{
+
+    public CoNectLogicalException(){
+        super(ResponseTemplateStatus.LOGICAL_ERROR);
+    }
+
+}

--- a/src/main/java/com/projectmatching/app/service/user/Impl/UserService.java
+++ b/src/main/java/com/projectmatching/app/service/user/Impl/UserService.java
@@ -16,6 +16,7 @@ import com.projectmatching.app.service.user.userdetail.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeanUtils;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,7 @@ public class UserService  {
     private final UserLikingRepository userLikingRepository;
     private final UserDetails userDetails;
 
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 사용자의
@@ -59,9 +61,9 @@ public class UserService  {
     //유저 상세 조회
     @Transactional(readOnly = true)
     public UserDto getUserDetail(Long id){
-        return UserDto.of(qUserRepository.find(id)
-                .orElseThrow(CoNectNotFoundException::new)
-        );
+        User user = qUserRepository.find(id).orElseThrow(CoNectNotFoundException::new);
+        applicationEventPublisher.publishEvent(user);
+        return UserDto.of(user);
 
     }
 

--- a/src/main/java/com/projectmatching/app/service/user/Impl/UserService.java
+++ b/src/main/java/com/projectmatching/app/service/user/Impl/UserService.java
@@ -20,6 +20,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;

--- a/src/main/java/com/projectmatching/app/util/InMemoryUtil.java
+++ b/src/main/java/com/projectmatching/app/util/InMemoryUtil.java
@@ -4,6 +4,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class InMemoryUtil {
-    static public Map<Long, Integer> readCntMap = new ConcurrentHashMap<>();
+    static public final Map<Long, Integer> readCntMap = new ConcurrentHashMap<>();
 
 }

--- a/src/main/java/com/projectmatching/app/util/InMemoryUtil.java
+++ b/src/main/java/com/projectmatching/app/util/InMemoryUtil.java
@@ -1,0 +1,9 @@
+package com.projectmatching.app.util;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryUtil {
+    static public Map<Long, Integer> readCntMap = new ConcurrentHashMap<>();
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,7 @@ spring:
     username: ${MP_DB_USERNAME}
     password: ${MP_DB_PASSWORD}
 
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
+++ b/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
@@ -1,0 +1,17 @@
+package com.projectmatching.app.service.readCount;
+
+
+import com.projectmatching.app.service.ServiceTest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+
+
+@SpringBootTest
+public class UserReadCountServiceTest  extends ServiceTest {
+
+
+
+}

--- a/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
+++ b/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
@@ -3,15 +3,33 @@ package com.projectmatching.app.service.readCount;
 
 import com.projectmatching.app.service.ServiceTest;
 
+import com.projectmatching.app.service.user.Impl.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-
+import org.springframework.test.annotation.Commit;
+import org.springframework.test.annotation.Rollback;
 
 
 @SpringBootTest
 public class UserReadCountServiceTest  extends ServiceTest {
 
+    @Autowired
+    private UserService userService;
+
+
+    @DisplayName("Write-Back 구현 테스트")
+    @Test
+    @Rollback(value = false)
+    void TESTING_WRITE_BACK_LOGIC(){
+
+        userService.getUserDetail(26L);
+        userService.getUserDetail(26L);
+        userService.getUserDetail(31L);
+        userService.getUserDetail(32L);
+        userService.getUserDetail(30L);
+    }
 
 
 }

--- a/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
+++ b/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
@@ -1,21 +1,83 @@
 package com.projectmatching.app.service.readCount;
 
 
+import com.projectmatching.app.config.handler.UserReadCntUpdateHandler;
+import com.projectmatching.app.constant.ServiceConstant;
+import com.projectmatching.app.domain.user.QUserRepository;
+import com.projectmatching.app.domain.user.UserRepository;
+import com.projectmatching.app.domain.user.entity.User;
 import com.projectmatching.app.service.ServiceTest;
 
 import com.projectmatching.app.service.user.Impl.UserService;
+import com.projectmatching.app.util.IdGenerator;
+import org.checkerframework.checker.units.qual.A;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.annotation.Commit;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.projectmatching.app.util.InMemoryUtil.readCntMap;
+import static org.mockito.Mockito.*;
 
 
 @SpringBootTest
 public class UserReadCountServiceTest  extends ServiceTest {
 
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserReadCntUpdateHandler userReadCntUpdateHandler;
 
 
+    @DisplayName("유저 조회수 카운팅 로직 성공 테스트")
+    @Test
+    @Transactional//롤백되도록
+    void GIVEN_USER_THEN_COUNTING_LOGIC_EXECUTE_TEST(){
+
+        User user = User.builder()
+                .id(1L)
+                .email("123@naver.com")
+                .pwd("1245u12uf!@#kjdfidfiadf")
+                .build();
+
+        userRepository.save(user);
+
+
+        userReadCntUpdateHandler.updateUserReadCnt(user);
+
+        //인메모리에 유저 조회수 정보 들어갔는지 확인
+        Assertions.assertEquals(1,readCntMap.size());
+
+
+    }
+
+
+
+
+    private User GenUser(){
+        User user = User.builder()
+                .id(IdGenerator.number())
+                .email("123@naver.com")
+                .pwd("1245u12uf!@#kjdfidfiadf")
+                .build();
+        return user;
+    }
 }

--- a/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
+++ b/src/test/java/com/projectmatching/app/service/readCount/UserReadCountServiceTest.java
@@ -15,21 +15,7 @@ import org.springframework.test.annotation.Rollback;
 @SpringBootTest
 public class UserReadCountServiceTest  extends ServiceTest {
 
-    @Autowired
-    private UserService userService;
 
-
-    @DisplayName("Write-Back 구현 테스트")
-    @Test
-    @Rollback(value = false)
-    void TESTING_WRITE_BACK_LOGIC(){
-
-        userService.getUserDetail(26L);
-        userService.getUserDetail(26L);
-        userService.getUserDetail(31L);
-        userService.getUserDetail(32L);
-        userService.getUserDetail(30L);
-    }
 
 
 }


### PR DESCRIPTION
# About

유저 조회수 업데이트 기능 구현

# Description

- Concurrent Hash map을 이용한 캐싱 로직 구현
- MAX_USER_READ_CNT_SIZE (현재는 10) 만큼 조회수 업데이트 필요한 유저가 쌓일 경우 한꺼번에 db에 업데이트함


# Result

@SpringbootTest를 통해 db에 조회수가 한꺼번에 업데이트 되는 것을 확인하였음.


#Ref
