### PR TITLE
 Issue#166 관련 수정

### DIFF
--- a/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechStack.java
+++ b/src/main/generated/com/projectmatching/app/domain/techStack/entity/QTechStack.java
@@ -26,7 +26,7 @@ public class QTechStack extends EntityPathBase<TechStack> {
 
     public final StringPath image = createString("image");
 
-    public final NumberPath<Integer> keys = createNumber("keys", Integer.class);
+    public final NumberPath<Integer> key = createNumber("key", Integer.class);
 
     public final SetPath<com.projectmatching.app.domain.team.entity.TeamTech, com.projectmatching.app.domain.team.entity.QTeamTech> teamTechs = this.<com.projectmatching.app.domain.team.entity.TeamTech, com.projectmatching.app.domain.team.entity.QTeamTech>createSet("teamTechs", com.projectmatching.app.domain.team.entity.TeamTech.class, com.projectmatching.app.domain.team.entity.QTeamTech.class, PathInits.DIRECT2);
 

--- a/src/main/java/com/projectmatching/app/config/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/projectmatching/app/config/handler/OAuth2AuthenticationSuccessHandler.java
@@ -79,8 +79,8 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
     private UserDto toDto(OAuth2User oAuth2User) {
        Map<String,Object> attributes = oAuth2User.getAttributes();
         return UserDto.builder()
-                .email((String)attributes.get("email"))
-                .name((String)attributes.get("name")).build();
+                .email((String)attributes.get("email")).build();
+//                .userInfo.setName(((String)attributes.get("name"))).build();
 
     }
 }

--- a/src/main/java/com/projectmatching/app/domain/techStack/dto/TechStackDto.java
+++ b/src/main/java/com/projectmatching/app/domain/techStack/dto/TechStackDto.java
@@ -4,9 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.projectmatching.app.domain.techStack.entity.TechStack;
 import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Id;
-
 @Getter
 @Setter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -15,7 +12,7 @@ import javax.persistence.Id;
 @JsonInclude(JsonInclude.Include.NON_NULL) //null 이면 생성되지 않음
 public class TechStackDto {
 
-    private Integer keys;
+    private Integer key;
 
     private String category;
 
@@ -26,7 +23,7 @@ public class TechStackDto {
 
     public static TechStackDto of(TechStack techStack){
         TechStackDto techStackDto = new TechStackDto();
-        techStackDto.keys = techStack.getKeys();
+        techStackDto.key = techStack.getKey();
         techStackDto.category = techStack.getCategory();
         techStackDto.techName = techStack.getTechName();
         techStackDto.image = techStack.getImage();

--- a/src/main/java/com/projectmatching/app/domain/techStack/entity/TechStack.java
+++ b/src/main/java/com/projectmatching/app/domain/techStack/entity/TechStack.java
@@ -22,8 +22,8 @@ public class TechStack {
     @Id
     private Long id;
 
-    @Column(columnDefinition = "BIGINT",name = "`keys`")
-    private Integer keys;
+    @Column(columnDefinition = "BIGINT",name = "`key`")
+    private Integer key;
 
     private String category;
 

--- a/src/main/java/com/projectmatching/app/domain/user/dto/UserDto.java
+++ b/src/main/java/com/projectmatching/app/domain/user/dto/UserDto.java
@@ -20,7 +20,7 @@ import static com.projectmatching.app.util.StreamUtil.map;
 
 @Getter
 @Setter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL) //null 이면 생성되지 않음
@@ -28,14 +28,11 @@ public class UserDto {
 
     private Long id;
 
-    private String oauthId;
+    private UserInfo userInfo;
     private String email;
-    private String name;
     private String portfolio;
     private String slogan;
-    private String img;
     private String content;//자기소개
-
     private String hopeSession; //원하는 작업기간
     private String job; //직업
     private String status;
@@ -51,6 +48,7 @@ public class UserDto {
     public static UserDto of(User user){
         UserDto userDto = createEmpty();
         BeanUtils.copyProperties(user, userDto);
+        userDto.userInfo = UserInfo.of(user);
         userDto.commentCnt = user.getUserComments().size();
         userDto.likeCnt = user.getRespected();
         userDto.skills = user.getSkills().stream().map(UserTech::toTechStack)

--- a/src/main/java/com/projectmatching/app/util/AuthTokenProvider.java
+++ b/src/main/java/com/projectmatching/app/util/AuthTokenProvider.java
@@ -38,7 +38,6 @@ import static com.projectmatching.app.constant.JwtConstant.*;
 @Getter @Setter
 public class AuthTokenProvider {
 
-
     private static Key key;
     private String secretKey = Secret.JWT_SECRET_KEY;
 
@@ -66,9 +65,9 @@ public class AuthTokenProvider {
         Claims claims = Jwts.claims();
         claims.put(CLAIM_ROLE, Role.USER); // 정보는 key / value 쌍으로 저장된다.
         claims.put(CLAIM_EMAIL,user.getEmail());
-        claims.put(CLAIM_NAME,user.getName());
+        claims.put(CLAIM_NAME,user.getUserInfo().getName());
         claims.put(CLAIM_ID,user.getId());
-        claims.put(CLAIM_IMG,user.getImg());
+        claims.put(CLAIM_IMG,user.getUserInfo().getImage());
         Date now = new Date();
         return Jwts.builder()
                 .setClaims(claims) // 정보 저장


### PR DESCRIPTION
# About

Issue#166 관련 수정

# Description

1. key로 수정했습니다
2. 지금도 기술스택 api에는 이미지를 담아서 주게 되어있습니다. 지금 나타나지 않는것은 아직 아무런 이미지도 저장이 되어있지 않기 때문입니다.
즉, null값이면 전달이 안되기때문에 안 주는것처럼 보이는 것입니다. 곧 제가 기술스택 이미지를 추가하도록 하겠습니다. 
3. 이것은 현재 프론트 엔드에서 구현되어있는 기술스택 중복방지 로직으로 충분해보입니다. 만일 모종의 이유로 버그가 생겨 중복 저장된다고 쳐도 사용자는 유저 프로필을 수정함으로써 고칠 수 있을것이라 생각합니다. 기술 스택 중복은 클라이언트와 서버에서 두번 체크할 정도로  큰 문제가 아닌거 같습니다. 우선순위를 뒤로 미뤄도 될거같습니다. 문제가 있다면 알려주세요
4. 유저 info 담아서 주도록 수정했습니다.
# Result
<img width="1146" alt="스크린샷 2022-09-05 오후 10 55 42" src="https://user-images.githubusercontent.com/48795102/188465781-0928c816-e427-4a30-ada0-3fe68a6af0dd.png">

ex) 실행, 테스트 결과 또는 사진 첨부

# Ref
 #166 