### PR TITLE
팀 간략 조회시 id 표시 및 상세 조회시 순환 참조 문제 해결

### DIFF
--- a/src/main/java/com/projectmatching/app/domain/comment/entity/TeamComment.java
+++ b/src/main/java/com/projectmatching/app/domain/comment/entity/TeamComment.java
@@ -26,7 +26,6 @@ import static java.util.Objects.nonNull;
 public class TeamComment extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
     private Long id;
 
     @ToString.Exclude

--- a/src/main/java/com/projectmatching/app/domain/liking/dto/TeamLikingDto.java
+++ b/src/main/java/com/projectmatching/app/domain/liking/dto/TeamLikingDto.java
@@ -1,0 +1,35 @@
+package com.projectmatching.app.domain.liking.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.projectmatching.app.domain.liking.entity.TeamLiking;
+import com.projectmatching.app.domain.team.dto.TeamDto;
+import com.projectmatching.app.domain.user.dto.UserInfo;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) //null 이면 생성되지 않음
+public class TeamLikingDto {
+
+    private Long id;
+
+    private UserInfo user;
+
+    private TeamDto teamDto;
+
+
+    public static TeamLikingDto of(TeamLiking teamLiking){
+
+        TeamLikingDto teamLikingDto = new TeamLikingDto();
+        teamLikingDto.id =  teamLiking.getId();
+        teamLikingDto.user = UserInfo.of(teamLiking.getUser());
+        teamLikingDto.teamDto = TeamDto.of(teamLiking.getTeam());
+
+        return teamLikingDto;
+
+    }
+
+}

--- a/src/main/java/com/projectmatching/app/domain/team/dto/TeamDto.java
+++ b/src/main/java/com/projectmatching/app/domain/team/dto/TeamDto.java
@@ -1,20 +1,21 @@
 package com.projectmatching.app.domain.team.dto;
 
+import com.projectmatching.app.domain.comment.dto.TeamCommentDto;
 import com.projectmatching.app.domain.comment.entity.TeamComment;
+import com.projectmatching.app.domain.liking.dto.TeamLikingDto;
+import com.projectmatching.app.domain.liking.dto.UserLikingDto;
 import com.projectmatching.app.domain.liking.entity.TeamLiking;
 import com.projectmatching.app.domain.team.entity.Team;
 import com.projectmatching.app.domain.team.entity.TeamTech;
 import com.projectmatching.app.domain.user.dto.UserInfo;
+import com.projectmatching.app.domain.user.dto.users.UserTeamDto;
 import com.projectmatching.app.domain.user.entity.UserTeam;
-import com.projectmatching.app.util.StreamUtil;
-import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.springframework.beans.BeanUtils;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
@@ -31,27 +32,30 @@ public class TeamDto {
     private String session;
 
     private String content;
-
-
     private Long readCnt;
-    @ApiModelProperty(name = "해당 팀에 속한 유저들")
-    private List<UserTeam> userTeamList;
+    private List<UserTeamDto> userTeamList;
 
+    private List<TeamCommentDto> comments;
 
-    private List<TeamComment> comments;
-    @ApiModelProperty(name = "해당 팀을 좋아요함 유저정보")
-    private List<TeamLiking> teamLikings;
+    private List<TeamLikingDto> teamLikings;
 
-    @ApiModelProperty(name = "해당 팀의 기술 스택들")
-    private List<TeamTech> teamTeches;
+    private List<TeamTechDto> teamTeches;
 
     public static TeamDto of(Team team){
         TeamDto teamDto = new TeamDto();
         BeanUtils.copyProperties(team,teamDto);
-        teamDto.comments = team.getTeamComments().stream().collect(Collectors.toList());
-        teamDto.userTeamList = team.getUserTeams().stream().collect(Collectors.toList());
-        teamDto.teamLikings = team.getTeamLikings().stream().collect(Collectors.toList());
-        teamDto.teamTeches = team.getTeamTeches().stream().collect(Collectors.toList());
+        teamDto.comments = team.getTeamComments().stream().map(TeamCommentDto::of)
+                .collect(Collectors.toList());
+
+        teamDto.userTeamList = team.getUserTeams().stream()
+                .map(UserTeamDto::forTeamOf).collect(Collectors.toList());
+
+        teamDto.teamLikings = team.getTeamLikings().stream()
+                .map(TeamLikingDto::of)
+                .collect(Collectors.toList());
+        teamDto.teamTeches = team.getTeamTeches().stream()
+                .map(TeamTechDto::of )
+                .collect(Collectors.toList());
 
         return teamDto;
     }

--- a/src/main/java/com/projectmatching/app/domain/team/dto/TeamSimpleDto.java
+++ b/src/main/java/com/projectmatching/app/domain/team/dto/TeamSimpleDto.java
@@ -18,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TeamSimpleDto {
 
+    private Long id;
     private String name;
     private UserInfo userInfo;
     private String session;

--- a/src/main/java/com/projectmatching/app/domain/team/dto/TeamTechDto.java
+++ b/src/main/java/com/projectmatching/app/domain/team/dto/TeamTechDto.java
@@ -1,0 +1,28 @@
+package com.projectmatching.app.domain.team.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.projectmatching.app.domain.team.entity.TeamTech;
+import com.projectmatching.app.domain.techStack.dto.TechStackDto;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) //null 이면 생성되지 않음
+public class TeamTechDto {
+
+    private Long id;
+
+    private TechStackDto techStack;
+
+
+    public static TeamTechDto of(TeamTech teamTech){
+        TeamTechDto teamTechDto = new TeamTechDto();
+        teamTechDto.id = teamTech.getId();
+        teamTechDto.setTechStack(TechStackDto.of(teamTech.getTechStack()));
+        return teamTechDto;
+    }
+
+}

--- a/src/main/java/com/projectmatching/app/domain/team/entity/Team.java
+++ b/src/main/java/com/projectmatching/app/domain/team/entity/Team.java
@@ -51,25 +51,25 @@ public class Team extends BaseTimeEntity {
     private Long ownerId;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
-    @BatchSize(size = 8)
     @Builder.Default
+    @ToString.Exclude
     private Set<UserTeam> userTeams = new HashSet<>();
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
-    @BatchSize(size = 8)
     @Builder.Default
+    @ToString.Exclude
     private Set<TeamComment> teamComments = new HashSet<>();
 
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
-    @BatchSize(size = 8)
     @Builder.Default
+    @ToString.Exclude
     private Set<TeamTech> teamTeches = new HashSet<>();
 
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
-    @BatchSize(size = 8)
     @Builder.Default
+    @ToString.Exclude
     private Set<TeamLiking> teamLikings = new HashSet<>();
 
     public void updateWith(TeamRequestDto teamRequestDto){

--- a/src/main/java/com/projectmatching/app/domain/user/dto/users/UserTeamDto.java
+++ b/src/main/java/com/projectmatching/app/domain/user/dto/users/UserTeamDto.java
@@ -1,0 +1,54 @@
+package com.projectmatching.app.domain.user.dto.users;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.projectmatching.app.domain.team.entity.Team;
+import com.projectmatching.app.domain.user.dto.UserInfo;
+import com.projectmatching.app.domain.user.entity.User;
+import com.projectmatching.app.domain.user.entity.UserTeam;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) //null 이면 생성되지 않음
+public class UserTeamDto {
+
+    private Long id;
+
+    private Long teamId;
+
+    private UserInfo user;
+
+
+    /**
+     * 팀에 소속한 유저 정보를 반환
+     * @param userTeam
+     * @return UserTeamDto(only UserInfo)
+     */
+    public static UserTeamDto forTeamOf(UserTeam userTeam){
+
+        UserTeamDto userTeamDto = new UserTeamDto();
+        userTeamDto.setUser(UserInfo.of(userTeam.getUser()));
+
+        return userTeamDto;
+
+    }
+
+    /**
+     * 유저가 속한 팀들을 반환
+     * @param userTeam
+     * @return UserTeamDto(only teamId)
+     */
+    public static UserTeamDto forUserOf(UserTeam userTeam){
+
+        UserTeamDto userTeamDto = new UserTeamDto();
+        userTeamDto.setTeamId(userTeamDto.getTeamId());
+
+        return userTeamDto;
+    }
+
+
+
+}


### PR DESCRIPTION
# About

팀 간략 조회시 id 표시 및 상세 조회시 순환 참조 문제 해결

# Description

엔티티간의 순환 참조로 인하여 json파싱 에러가 나타났었습니다.
Team 엔티티에 들어가는 칼럼 정보들을 위한 Dto를 작성해주었습니다.

# Result


# Ref
https://www.notion.so/0c6b0ff13c0e484793d8982250963db5?p=4e3827c340ed468a970228c212f5db4e&pm=s
