### PR TITLE
[FE] 기술스택 팝업에서 선택한 목록 표시할 수 있는 옵션 추가

### DIFF
--- a/webapp/src/components/TechStackSelectInput/TechStackOptions.jsx
+++ b/webapp/src/components/TechStackSelectInput/TechStackOptions.jsx
@@ -24,15 +24,17 @@ export default function TechStackOptions({
   handleClickOption,
   forceRefetchTeckStackOptions,
 }) {
-  if (techStackOptionsApiState.isLoading) return <>...</>;
+  if (techStackOptionsApiState.isLoading) return <S.OptionCategory>...</S.OptionCategory>;
   if (techStackOptionsApiState.error) {
     const { error } = techStackOptionsApiState;
     return (
-      <Callback
-        errorStatus={error.httpStatus}
-        errorMessage={error.message}
-        forceRefetch={forceRefetchTeckStackOptions}
-      />
+      <S.OptionCategory>
+        <Callback
+          errorStatus={error.httpStatus}
+          errorMessage={error.message}
+          forceRefetch={forceRefetchTeckStackOptions}
+        />
+      </S.OptionCategory>
     );
   }
 

--- a/webapp/src/components/TechStackSelectInput/TechStackSelectInput.stories.jsx
+++ b/webapp/src/components/TechStackSelectInput/TechStackSelectInput.stories.jsx
@@ -97,6 +97,17 @@ WtihMultiValue.args = {
   placeholder: 'selectedTechSkills',
 };
 
+export const WithErrorInSelectedOptionViewer = Template.bind({});
+WithErrorInSelectedOptionViewer.args = {
+  selectedTechSkills: [],
+  name: 'name',
+  label: 'label',
+  placeholder: 'Error',
+  isError: true,
+  helperText: '에러 입니다.',
+  showSelectedOption: true,
+};
+
 export const WithError = Template.bind({});
 WithError.args = {
   selectedTechSkills: [],

--- a/webapp/src/components/TechStackSelectInput/TechStackSelectInput.stories.jsx
+++ b/webapp/src/components/TechStackSelectInput/TechStackSelectInput.stories.jsx
@@ -48,7 +48,7 @@ WtihValue.args = {
 
 export const WtihSelectedOptionViewer = Template.bind({});
 WtihSelectedOptionViewer.args = {
-  showSelectedOption: true,
+  isDropdownType: true,
   selectedTechSkills: [
     {
       id: 500,
@@ -105,7 +105,7 @@ WithErrorInSelectedOptionViewer.args = {
   placeholder: 'Error',
   isError: true,
   helperText: '에러 입니다.',
-  showSelectedOption: true,
+  isDropdownType: true,
 };
 
 export const WithError = Template.bind({});

--- a/webapp/src/components/TechStackSelectInput/TechStackSelectInput.style.js
+++ b/webapp/src/components/TechStackSelectInput/TechStackSelectInput.style.js
@@ -72,15 +72,17 @@ export const SelectedStacks = styled.div`
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
-  gap: 4px;
+  gap: 10px;
 `;
 
 export const SingleStack = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter({ direction: 'row' })};
-  padding: 2px 0 2px 6px;
-  background-color: ${({ theme: { colors } }) => colors.secondary.shadow};
-  &:hover {
-    background-color: ${({ theme: { colors } }) => colors.secondary.light};
+  > img {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    /* Color/Primary/900 */
+    border: 1px solid #036eff;
   }
 `;
 
@@ -126,6 +128,7 @@ export const Select = styled.div`
   max-height: 300px;
   overflow-y: auto;
   border: 1px solid ${({ theme: { colors } }) => colors.primary.normal};
+  background-color: ${({ theme: { colors } }) => colors.greyScale.white};
   border-radius: 5px;
   padding: 0 57px;
   padding-top: 24px;
@@ -213,7 +216,7 @@ export const CloseNormal = styled(CloseNormalIcon)`
 `;
 
 export const Error = styled.span`
-  margin: 1rem 0;
+  margin-bottom: 1rem;
   align-self: flex-start;
   padding-left: 1rem;
   color: ${({ theme }) => theme.colors.important.normal};

--- a/webapp/src/components/TechStackSelectInput/TechStackSelectInput.style.js
+++ b/webapp/src/components/TechStackSelectInput/TechStackSelectInput.style.js
@@ -100,7 +100,12 @@ export const PlaceHolder = styled.label`
 `;
 
 export const Select = styled.div`
-  ${({ isDropdownOpen }) => {
+  ${({ isDropdownOpen, isDropdownType }) => {
+    if (isDropdownType) {
+      return css`
+        display: block;
+      `;
+    }
     if (isDropdownOpen) {
       return css`
         display: block;
@@ -111,15 +116,15 @@ export const Select = styled.div`
     `;
   }}
 
-  ${({ showSelectedOption }) => {
-    if (showSelectedOption) {
+  ${({ isDropdownType }) => {
+    if (isDropdownType) {
       return css`
-        position: absolute;
-        top: 105%;
+        position: relative;
       `;
     }
     return css`
-      position: relative;
+      position: absolute;
+      top: 105%;
     `;
   }};
 

--- a/webapp/src/components/TechStackSelectInput/TechStackSelectedViewer.jsx
+++ b/webapp/src/components/TechStackSelectInput/TechStackSelectedViewer.jsx
@@ -7,6 +7,7 @@ TechStackSelectedViewer.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   isDropdownOpen: PropTypes.bool.isRequired,
   isValues: PropTypes.bool.isRequired,
+  helperText: PropTypes.string,
   parent: PropTypes.object.isRequired,
   selectedTechSkills: PropTypes.array.isRequired,
   placeholder: PropTypes.string.isRequired,
@@ -21,6 +22,7 @@ export default function TechStackSelectedViewer({
   parent,
   isDropdownOpen,
   isValues,
+  helperText,
   selectedTechSkills,
   handleClickTargetDelete,
   placeholder,
@@ -41,15 +43,14 @@ export default function TechStackSelectedViewer({
     <S.ValueViewer isError={isError} ref={parent} isDropdownOpen={isDropdownOpen}>
       {isValues ? (
         <S.SelectedStacks>
-          {selectedTechSkills.map(({ id, label, value }) => (
-            <S.SingleStack key={id}>
-              <span>{label}</span>
-              <S.CloseNormal onClick={() => handleClickTargetDelete({ targetId: id })} />
+          {selectedTechSkills.map(({ id, label, value, image }) => (
+            <S.SingleStack key={id} onClick={() => handleClickTargetDelete({ targetId: id })}>
+              <img src={image} alt={label} />
             </S.SingleStack>
           ))}
         </S.SelectedStacks>
       ) : (
-        <S.PlaceHolder>{placeholder}</S.PlaceHolder>
+        <S.PlaceHolder>{isError ? <S.Error>{helperText}</S.Error> : placeholder}</S.PlaceHolder>
       )}
       <S.ButtonContainer>
         {showLoaderWithClearButton}

--- a/webapp/src/components/TechStackSelectInput/TechStackSelectedViewer.jsx
+++ b/webapp/src/components/TechStackSelectInput/TechStackSelectedViewer.jsx
@@ -32,7 +32,7 @@ export default function TechStackSelectedViewer({
   const AngleButton = isDropdownOpen ? S.UpAngle : S.DownAngle;
 
   const ClearButton = selectedTechSkills && (
-    <S.ClearableButton onClick={handleClickReset}>
+    <S.ClearableButton type="button" onClick={handleClickReset}>
       <S.CloseNormal />
     </S.ClearableButton>
   );

--- a/webapp/src/components/TechStackSelectInput/index.jsx
+++ b/webapp/src/components/TechStackSelectInput/index.jsx
@@ -14,7 +14,7 @@ TechStackSelectInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   placeholder: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  showSelectedOption: PropTypes.bool,
+  isDropdownType: PropTypes.bool,
   label: PropTypes.string,
   isError: PropTypes.bool,
   helperText: PropTypes.string,
@@ -31,7 +31,7 @@ export default function TechStackSelectInput({
   placeholder,
   name,
   defaultOption,
-  showSelectedOption = true,
+  isDropdownType = true,
   isError = false,
   helperText,
   customStyle,
@@ -90,7 +90,7 @@ export default function TechStackSelectInput({
       {...rest}
     >
       {label && <S.Label>{label}</S.Label>}
-      {showSelectedOption && (
+      {isDropdownType && (
         <TechStackSelectedViewer
           isError={isError}
           parent={parent}
@@ -105,8 +105,8 @@ export default function TechStackSelectInput({
           closeDropdown={closeDropdown}
         />
       )}
-      {!showSelectedOption && isError && <S.Error>{helperText}</S.Error>}
-      <S.Select isDropdownOpen={isDropdownOpen} showSelectedOption={showSelectedOption}>
+      {!isDropdownType && isError && <S.Error>{helperText}</S.Error>}
+      <S.Select isDropdownOpen={isDropdownOpen} isDropdownType={!isDropdownType}>
         <TechStackOptions
           techStackOptionsApiState={techStackOptionsApiState}
           selectedTechSkills={selectedTechSkills}

--- a/webapp/src/components/TechStackSelectInput/index.jsx
+++ b/webapp/src/components/TechStackSelectInput/index.jsx
@@ -31,7 +31,7 @@ export default function TechStackSelectInput({
   placeholder,
   name,
   defaultOption,
-  showSelectedOption = false,
+  showSelectedOption = true,
   isError = false,
   helperText,
   customStyle,
@@ -97,6 +97,7 @@ export default function TechStackSelectInput({
           isDropdownOpen={isDropdownOpen}
           isValues={isValues}
           isLoading={techStackOptionsApiState.isLoading}
+          helperText={helperText}
           selectedTechSkills={selectedTechSkills}
           handleClickTargetDelete={handleClickTargetDelete}
           placeholder={placeholder}
@@ -104,8 +105,8 @@ export default function TechStackSelectInput({
           closeDropdown={closeDropdown}
         />
       )}
-      {isError && <S.Error>{helperText}</S.Error>}
-      <S.Select isDropdownOpen showSelectedOption={showSelectedOption}>
+      {!showSelectedOption && isError && <S.Error>{helperText}</S.Error>}
+      <S.Select isDropdownOpen={isDropdownOpen} showSelectedOption={showSelectedOption}>
         <TechStackOptions
           techStackOptionsApiState={techStackOptionsApiState}
           selectedTechSkills={selectedTechSkills}

--- a/webapp/src/pages/EssentialInfo/SubPages/Skills.jsx
+++ b/webapp/src/pages/EssentialInfo/SubPages/Skills.jsx
@@ -24,7 +24,7 @@ export default function Skills() {
           onChange={onChangeHandlerWithSelect}
           isError={isSkillsValidateError}
           helperText={validateError.techSkills}
-          showSelectedOption={false}
+          isDropdownType={false}
         />
       </S.TechSkillContainer>
       <S.NextButtonContainer>

--- a/webapp/src/pages/EssentialInfo/SubPages/Skills.jsx
+++ b/webapp/src/pages/EssentialInfo/SubPages/Skills.jsx
@@ -24,6 +24,7 @@ export default function Skills() {
           onChange={onChangeHandlerWithSelect}
           isError={isSkillsValidateError}
           helperText={validateError.techSkills}
+          showSelectedOption={false}
         />
       </S.TechSkillContainer>
       <S.NextButtonContainer>

--- a/webapp/src/pages/NewTeamPost/NewTeamPostDetail.jsx
+++ b/webapp/src/pages/NewTeamPost/NewTeamPostDetail.jsx
@@ -3,7 +3,6 @@ import { newTeamPostParser } from 'service/team/team.parser';
 import { newTeamPostValidation } from 'service/team/team.validation';
 import { useToastNotificationAction } from 'contexts/ToastNotification';
 import { notifyNewMessage } from 'contexts/ToastNotification/action';
-import { TOAST_TYPE } from 'contexts/ToastNotification/type';
 import useForm from 'hooks/useForm';
 import useAxios from 'hooks/useAxios';
 import teamApi from 'api/team.api';


### PR DESCRIPTION
# About

기술스택 팝업에서 선택한 목록 표시해주기 
- `isDropdownType`가 true이면 팝업형식으로 렌더링
- 기술스택 팝업창을 사용하는 페이지들 중 필수정보입력페이지를 제외한 나머지 페이지(팀 생성, 팀 수정, 유저프로필수정)에서 팝업형식으로 UI변경

# Description

### 팝업창으로 보여주기

기본 설정 `isDropdownType = true`

### 필수정보입력페이지
- 기존과 같이 선택한 기술이미지를 표시

```jsx
 <TechStackSelectInput
           {/* 생략  */}
          isDropdownType={false}
        />
```

<img width="684" alt="스크린샷 2022-09-28 오후 7 44 47" src="https://user-images.githubusercontent.com/71386219/192759750-7a280fbe-eacc-4149-ae14-1fd58dbd5552.png">

### 필수정보입력페이지를 제외한 나머지 페이지(팀 생성, 팀 수정, 유저프로필수정)
- dropdown 형식으로 변경

```jsx
 <TechStackSelectInput
           {/* 생략  */}
          showSelectedOption
        />
``` 

<img width="552" alt="스크린샷 2022-09-28 오후 7 39 30" src="https://user-images.githubusercontent.com/71386219/192758803-474c2eea-c24b-43de-9f8c-b5bd8d6dd976.png">


- 선택한 이미지는 별도로 상단에 표시
<img width="536" alt="스크린샷 2022-09-28 오후 7 39 09" src="https://user-images.githubusercontent.com/71386219/192758727-99b6124c-093b-42a0-8e1e-68c657c7b098.png">


# Ref

#198 
