### PR TITLE
[FE] styled-component 디버깅을 위한 styled-component/macro 적용

### DIFF
--- a/webapp/src/assets/fonts/index.js
+++ b/webapp/src/assets/fonts/index.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from 'styled-components/macro';
 
 import NotoSansKR_Bold from './NotoSansKR-Bold.otf';
 import NotoSansKR_Regular from './NotoSansKR-Regular.otf';

--- a/webapp/src/assets/icons/icons.stories.jsx
+++ b/webapp/src/assets/icons/icons.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import CalendarSvg from './CalendarSvg';
 import ChatBubbleOvalSvg from './ChatBubbleOvalSvg';
 import EditPencilSvg from './EditPencilSvg';

--- a/webapp/src/components/CardsGrid/CardsGrid.style.js
+++ b/webapp/src/components/CardsGrid/CardsGrid.style.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Cards = styled.ul`
   display: grid;

--- a/webapp/src/components/CheckBox/style.js
+++ b/webapp/src/components/CheckBox/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const CheckBoxListWrapper = styled.ul`
   border: 1px solid #000;

--- a/webapp/src/components/ComentContainer/style.js
+++ b/webapp/src/components/ComentContainer/style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   width: 100%;

--- a/webapp/src/components/Common/BackButton/BackButton.style.js
+++ b/webapp/src/components/Common/BackButton/BackButton.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.button`
   position: absolute;

--- a/webapp/src/components/Common/Button/Button.stories.jsx
+++ b/webapp/src/components/Common/Button/Button.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { css } from 'styled-components';
+import { css } from 'styled-components/macro';
 import Button from './index';
 
 export default {

--- a/webapp/src/components/Common/Button/Button.style.js
+++ b/webapp/src/components/Common/Button/Button.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.button`
   ${({ theme: { mixin } }) => mixin.flexCenter({})}

--- a/webapp/src/components/Common/CheckInput/CheckInput.stories.jsx
+++ b/webapp/src/components/Common/CheckInput/CheckInput.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { css } from 'styled-components';
+import { css } from 'styled-components/macro';
 import CheckInput from './index';
 
 export default {

--- a/webapp/src/components/Common/CheckInput/CheckInput.style.js
+++ b/webapp/src/components/Common/CheckInput/CheckInput.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.div`
   display: flex;

--- a/webapp/src/components/Common/Divider/Divider.style.js
+++ b/webapp/src/components/Common/Divider/Divider.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const RowContainer = styled.div`
   height: 2px;

--- a/webapp/src/components/Common/Dropdown/style.js
+++ b/webapp/src/components/Common/Dropdown/style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const defaultStyle = {
   overlay: css`

--- a/webapp/src/components/Common/Image/style.js
+++ b/webapp/src/components/Common/Image/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Image = styled.img`
   width: 100%;

--- a/webapp/src/components/Common/Like/style.js
+++ b/webapp/src/components/Common/Like/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Heart = styled.button`
   width: 25px;

--- a/webapp/src/components/Common/SelectInput/SelectInput.style.js
+++ b/webapp/src/components/Common/SelectInput/SelectInput.style.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 /* eslint-disable consistent-return */
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import Divider from '../Divider';
 
 export const Container = styled.div`

--- a/webapp/src/components/Common/Tabs/style.js
+++ b/webapp/src/components/Common/Tabs/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Tabs = styled.ul`
   width: 100%;

--- a/webapp/src/components/Common/TextArea/TextArea.style.js
+++ b/webapp/src/components/Common/TextArea/TextArea.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.div`
   box-sizing: border-box;

--- a/webapp/src/components/Common/TextInput/TextInput.style.js
+++ b/webapp/src/components/Common/TextInput/TextInput.style.js
@@ -1,5 +1,5 @@
 /* eslint-disable consistent-return */
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   position: relative;

--- a/webapp/src/components/Common/UpperButton/UpperButton.style.js
+++ b/webapp/src/components/Common/UpperButton/UpperButton.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.button`
   position: fixed;

--- a/webapp/src/components/Common/WindowModal/style.js
+++ b/webapp/src/components/Common/WindowModal/style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const defaultStyle = {
   overlay: css`

--- a/webapp/src/components/GlobalNavigation/style.js
+++ b/webapp/src/components/GlobalNavigation/style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 // 상단 파란색 상자
 export const TopContainer = styled.div`

--- a/webapp/src/components/MarkdownEditor/MarkdownEditor.style.js
+++ b/webapp/src/components/MarkdownEditor/MarkdownEditor.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.div`
   width: 100%;

--- a/webapp/src/components/ProfileImg/style.js
+++ b/webapp/src/components/ProfileImg/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const ProfileImg = styled.img`
   width: 100%;

--- a/webapp/src/components/SocialLoginButtons/SocialLoginButtons.style.js
+++ b/webapp/src/components/SocialLoginButtons/SocialLoginButtons.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter({})}

--- a/webapp/src/components/TeamBelongCheckInput/TeamBelongCheckInput.style.js
+++ b/webapp/src/components/TeamBelongCheckInput/TeamBelongCheckInput.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.div``;
 

--- a/webapp/src/components/TeamCard/TeamCard.style.js
+++ b/webapp/src/components/TeamCard/TeamCard.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 // * : Card Container
 export const CardWrapper = styled.li`

--- a/webapp/src/components/TechSkills/TechSkills.style.js
+++ b/webapp/src/components/TechSkills/TechSkills.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div``;
 

--- a/webapp/src/components/TechStackSelectInput/TechStackSelectInput.style.js
+++ b/webapp/src/components/TechStackSelectInput/TechStackSelectInput.style.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 /* eslint-disable consistent-return */
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import Divider from 'components/Common/Divider';
 
 export const Container = styled.div`

--- a/webapp/src/components/ToastNotification/ToastNotification.style.js
+++ b/webapp/src/components/ToastNotification/ToastNotification.style.js
@@ -1,5 +1,5 @@
 // ref: https://github.com/uzochukwueddie/react-toast/blob/master/src/components/toast/Toast.css
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   font-size: 14px;

--- a/webapp/src/components/UserCard/UserCard.style.js
+++ b/webapp/src/components/UserCard/UserCard.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 // * : Card Container
 export const CardWrapper = styled.div`

--- a/webapp/src/layouts/layout.style.js
+++ b/webapp/src/layouts/layout.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const AppContainer = styled.div`
   width: 100vw;

--- a/webapp/src/pages/Callback/callback.style.js
+++ b/webapp/src/pages/Callback/callback.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   max-width: 1180px;

--- a/webapp/src/pages/EditTeamPost/EditTeamPost.style.js
+++ b/webapp/src/pages/EditTeamPost/EditTeamPost.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const ImgContainer = styled.div`
   display: flex;

--- a/webapp/src/pages/EditUserProfile/EditUserProfile.style.js
+++ b/webapp/src/pages/EditUserProfile/EditUserProfile.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   position: relative;

--- a/webapp/src/pages/EssentialInfo/EssentialInfo.style.js
+++ b/webapp/src/pages/EssentialInfo/EssentialInfo.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 // 레이아웃
 export const Layout = styled.div`

--- a/webapp/src/pages/Login/Login.style.js
+++ b/webapp/src/pages/Login/Login.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   width: 750px;

--- a/webapp/src/pages/Main/style.js
+++ b/webapp/src/pages/Main/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Header = styled.header`
   height: 38px;

--- a/webapp/src/pages/MyList/style.js
+++ b/webapp/src/pages/MyList/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.div``;
 

--- a/webapp/src/pages/MyPost/style.js
+++ b/webapp/src/pages/MyPost/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Container = styled.div``;
 export const BoardContainer = styled.div`

--- a/webapp/src/pages/NewTeamPost/NewTeamPost.style.js
+++ b/webapp/src/pages/NewTeamPost/NewTeamPost.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const ImgContainer = styled.div`
   display: flex;

--- a/webapp/src/pages/SignUp/SignUp.style.js
+++ b/webapp/src/pages/SignUp/SignUp.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   width: 750px;

--- a/webapp/src/pages/TeamBoard/style.js
+++ b/webapp/src/pages/TeamBoard/style.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const BoardWrapper = styled.div`
   width: 100%;

--- a/webapp/src/pages/TeamPost/TeamPost.style.js
+++ b/webapp/src/pages/TeamPost/TeamPost.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   position: relative;

--- a/webapp/src/pages/UserBoard/style.js
+++ b/webapp/src/pages/UserBoard/style.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const BoardWrapper = styled.div`
   width: 100%;

--- a/webapp/src/pages/UserPost/UserPost.style.js
+++ b/webapp/src/pages/UserPost/UserPost.style.js
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 export const Container = styled.div`
   position: relative;

--- a/webapp/src/styles/GlobalStyles.js
+++ b/webapp/src/styles/GlobalStyles.js
@@ -1,5 +1,5 @@
 import fonts from 'assets/fonts';
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from 'styled-components/macro';
 
 import Normalize from './Normalize';
 

--- a/webapp/src/styles/Normalize.js
+++ b/webapp/src/styles/Normalize.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from 'styled-components/macro';
 
 const Normalize = css`
   /*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */

--- a/webapp/src/styles/index.jsx
+++ b/webapp/src/styles/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider } from 'styled-components/macro';
 import theme from './theme';
 import GlobalStyles from './GlobalStyles';
 

--- a/webapp/src/styles/mixin.js
+++ b/webapp/src/styles/mixin.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from 'styled-components/macro';
 
 const mixin = {
   // flex

--- a/webapp/src/styles/theme.js
+++ b/webapp/src/styles/theme.js
@@ -1,4 +1,4 @@
-import { css } from 'styled-components';
+import { css } from 'styled-components/macro';
 import mixin from './mixin';
 
 export const FONT = {


### PR DESCRIPTION
# About



# Description

styled-component(sc)는 스타일을 적용할 때  `.1u6w3vy `, `.dkz0Af` 등과 같이 css 클래스에 대해 고유한 해시를 생성합니다. 이덕분에 중복되지 않게 컴포넌트 단위로  css를 적용할 수 있지만 개발단계에서 디버깅할 때 불편함이 있습니다. 

이 때, 개발 단계에서 `파일 시스템 등의 컨텍스트를 기반으로 스타일이 지정된 구성 요소의 자동 주석을 통해 더 나은 디버깅`를 도와주는 [바벨 플러그인](https://github.com/styled-components/babel-plugin-styled-components)이 있습니다👏 

.FileName__StyledComponent-generatedHash에서와 같이 .Navbar__Item-sc-14eztoj-1과 같은 이름을 생성하여 요소/스타일을 소스를 찾을 수 있습니다

찾아보니 cra에서 따로 바벨 설정을 할 필요 없이 사용할 수 있더라구요. 
```diff
- import { css } from 'styled-components';
+ import { css } from 'styled-components/macro';
```

개발환경뿐만 아니라 배포환경에서도 적용됩니다. 렌더링 및 최적화에 어떤 장단점이 있는지는 파악하지 못했습니다. 😓

# Result

개발환경
<img width="1199" alt="스크린샷 2022-12-26 오후 3 06 49" src="https://user-images.githubusercontent.com/71386219/209509920-36cd1d1f-f0bf-4426-adf3-4cf62758c8f6.png">

배포환경
<img width="1221" alt="스크린샷 2022-12-26 오후 3 09 03" src="https://user-images.githubusercontent.com/71386219/209510118-cf36fb55-7e95-4e47-bdff-80ab29fa8046.png">

# Ref

https://styled-components.com/docs/tooling#babel-macro 

