### PR TITLE
[FE] 무한스크롤 버그 수정 및 유저 및 팀 보드 비었을 때 유도 UI추가

### DIFF
--- a/webapp/src/components/CardsGrid/CardsGrid.style.js
+++ b/webapp/src/components/CardsGrid/CardsGrid.style.js
@@ -1,5 +1,4 @@
-/* eslint-disable import/prefer-default-export */
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Cards = styled.ul`
   display: grid;
@@ -7,4 +6,21 @@ export const Cards = styled.ul`
   gap: 40px 20px;
   width: 100%;
   height: 100%;
+`;
+
+export const Empty = styled.div`
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+  padding-top: 150px;
+  ${({ theme: { mixin } }) => mixin.flexCenter({})}
+  gap: 12px;
+  > h3 {
+    ${({ theme: { fonts } }) => fonts.korean.subTitle};
+  }
+`;
+
+export const Button = css`
+  width: 300px;
+  height: 50px;
 `;

--- a/webapp/src/components/CardsGrid/index.jsx
+++ b/webapp/src/components/CardsGrid/index.jsx
@@ -1,23 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
+import Button from 'components/Common/Button';
 import * as S from './CardsGrid.style';
 
 CardsGrid.propTypes = {
   CardComponent: PropTypes.func.isRequired,
   cards: PropTypes.array.isRequired,
   clickLink: PropTypes.string,
+  emptyTrigger: PropTypes.shape({
+    emptyMessage: PropTypes.string.isRequired,
+    triggerLink: PropTypes.string.isRequired,
+    triggerMessage: PropTypes.string.isRequired,
+  }),
 };
 
-export default function CardsGrid({ CardComponent, cards, clickLink }) {
+export default function CardsGrid({ CardComponent, cards, clickLink, emptyTrigger }) {
+  const { emptyMessage, triggerLink, triggerMessage } = emptyTrigger;
   const navaigate = useNavigate();
   const handleClickCardComponent = (cardId) => {
     clickLink && navaigate(clickLink + cardId);
   };
+  const handleClickTriggerLink = () => navaigate(triggerLink);
   return (
     <S.Cards>
       {cards.length === 0 ? (
-        <div>Emtpy</div>
+        <S.Empty>
+          <h3>{emptyMessage}</h3>
+          <Button theme="primary" onClick={handleClickTriggerLink} customStyle={S.Button}>
+            {triggerMessage}
+          </Button>
+        </S.Empty>
       ) : (
         cards.map(({ id, ...cardInfo }) => (
           <CardComponent

--- a/webapp/src/constant/service.constant.js
+++ b/webapp/src/constant/service.constant.js
@@ -1,2 +1,17 @@
+import { ROUTE } from './route.constant';
+
 export const emailRegex = /^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\w+\.)+\w+$/i;
 export const passwordRegex = /(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&+=])(?=\S+$).{8,20}/;
+
+export const emptyTrigger = {
+  user: {
+    emptyMessage: '등록된 회원이 없네요😓',
+    triggerMessage: '회원가입을 해주세요!',
+    triggerLink: ROUTE.SIGN_UP,
+  },
+  team: {
+    emptyMessage: '등록된 팀이 없네요😓',
+    triggerMessage: '새로운 팀을 등록해주세요!',
+    triggerLink: ROUTE.NEW_POST,
+  },
+};

--- a/webapp/src/hoc/WithInfiniteScroll.jsx
+++ b/webapp/src/hoc/WithInfiniteScroll.jsx
@@ -1,80 +1,88 @@
-import React, { useEffect, useState } from 'react';
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 import useIntersect from 'hooks/useIntersect';
 import UpperButton from 'components/Common/UpperButton';
 import Callback from 'pages/Callback';
+import CardsGrid from 'components/CardsGrid';
 
-export default function WithInfiniteScroll({ Component, responseDataKey, axiosInstance }) {
-  return function Wrapper(props) {
-    const [loadMoreRef, page, resetPage] = useIntersect();
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState({ isError: false, msg: '' });
-    const [cardList, setCardList] = useState([]);
-    // const IsShowLoadRef = isLoading || error.isError ? 'block' : 'none'; // isLoading이 true이거나 isError가 true이면 ref엘리먼트를 보여주지 않음.
-    const [trigger, setTrigger] = useState(Date.now());
+WithInfiniteScroll.propTypes = {
+  CardComponent: PropTypes.element.isRequired,
+  clickLink: PropTypes.func.isRequired,
+  axiosInstance: PropTypes.object.isRequired,
+  emptyTrigger: PropTypes.shape({
+    emptyMessage: PropTypes.string.isRequired,
+    triggerLink: PropTypes.string.isRequired,
+    triggerMessage: PropTypes.string.isRequired,
+  }),
+};
 
-    const resetError = () => {
-      setError({ isError: false, msg: '' });
-      setCardList([]);
-      setIsLoading(false);
-    };
+export default function WithInfiniteScroll({
+  CardComponent,
+  clickLink,
+  axiosInstance,
+  emptyTrigger,
+}) {
+  const page = useRef(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState({ isError: false, msg: '' });
+  const [cardList, setCardList] = useState([]);
 
-    const refetcher = () => {
-      window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-      resetError();
-      resetPage();
-      setTrigger(Date.now());
-    };
-
-    const fetcher = async (lastPage, signal) => {
-      setIsLoading(true);
-      try {
-        const { data: responseCardList } = await axiosInstance({ params: { lastPage }, signal });
-        setCardList((prev) => [...prev, ...responseCardList]);
-      } catch (error) {
-        // src/api/errorHandler가 올바르게 작동하지 않은 경우 if문 실행
-        if (typeof error !== 'string') {
-          setError({
-            isError: true,
-            msg: '데이터를 가져오는 도중 에러가 발생했습니다. ',
-          });
-        } else {
-          setError({
-            isError: true,
-            msg: error.message,
-          });
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    useEffect(() => {
-      const controller = new AbortController();
-      const { signal } = controller;
-      fetcher(page, signal);
-      return () => {
-        controller.abort();
-      };
-    }, [page, trigger]);
-
-    if (error.isError)
-      return (
-        <Callback
-          errorStatus={error.httpStatus}
-          errorMessage={error.msg}
-          forceRefetch={refetcher}
-        />
-      );
-
-    const propsWithResponseData = { ...props, [responseDataKey]: cardList };
-    return (
-      <>
-        {!isLoading && <Component {...propsWithResponseData} />}
-        <div ref={loadMoreRef} style={{ height: '100px', width: '100px' }}>
-          {isLoading && <div>Loading...</div>}
-        </div>
-        <UpperButton />
-      </>
-    );
+  const resetError = () => {
+    setError({ isError: false, msg: '' });
+    setCardList([]);
+    setIsLoading(false);
   };
+
+  const fetcher = async (signal) => {
+    setIsLoading(true);
+    try {
+      const { data: responseCardList } = await axiosInstance({
+        params: { lastPage: page.current },
+        signal,
+      });
+      setCardList((prev) => [...prev, ...responseCardList]);
+    } catch (error) {
+      // src/api/errorHandler가 올바르게 작동하지 않은 경우 if문 실행
+      if (typeof error !== 'string') {
+        setError({
+          isError: true,
+          msg: '데이터를 가져오는 도중 에러가 발생했습니다. ',
+        });
+      } else {
+        setError({
+          isError: true,
+          msg: error.message,
+        });
+      }
+    } finally {
+      setIsLoading(false);
+      page.current += 1;
+    }
+  };
+
+  const refetcher = () => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+    resetError();
+    page.current = 0;
+    fetcher();
+  };
+
+  const [loadMoreRef] = useIntersect(fetcher);
+  if (error.isError)
+    return (
+      <Callback errorStatus={error.httpStatus} errorMessage={error.msg} forceRefetch={refetcher} />
+    );
+
+  return (
+    <>
+      <CardsGrid
+        CardComponent={CardComponent}
+        cards={cardList}
+        clickLink={clickLink}
+        emptyTrigger={emptyTrigger}
+      />
+      <div ref={loadMoreRef}>{isLoading && <div>Loading...</div>}</div>
+      <UpperButton />
+    </>
+  );
 }

--- a/webapp/src/hoc/WithInfiniteScroll.jsx
+++ b/webapp/src/hoc/WithInfiniteScroll.jsx
@@ -36,7 +36,6 @@ export default function WithInfiniteScroll({
   const fetcher = async (signal) => {
     setIsLoading(true);
     try {
-      if (isLoading) return;
       const { data: responseCardList } = await axiosInstance({
         params: { lastPage: page.current },
         signal,
@@ -70,6 +69,15 @@ export default function WithInfiniteScroll({
 
   const [loadMoreRef] = useIntersect(fetcher);
 
+  /**
+   * 타겟 요소의 display속성을 설정하는 함수: 에러 상황일 때 추가요청 방지 용도
+   * @returns "none" : "block" 타겟요소의 display 속성
+   */
+  const observerRefDisplay = () => {
+    if (error.isError) return 'none';
+    return isLoading ? 'none' : 'block';
+  };
+
   return (
     <>
       {error.isError ? (
@@ -86,7 +94,9 @@ export default function WithInfiniteScroll({
           emptyTrigger={emptyTrigger}
         />
       )}
-      <div ref={loadMoreRef}>{isLoading && !error.isError && <div>Loading...</div>}</div>
+      <div style={{ display: observerRefDisplay() }} ref={loadMoreRef}>
+        {isLoading && !error.isError && <div>Loading...</div>}
+      </div>
       <UpperButton />
     </>
   );

--- a/webapp/src/hooks/useIntersect.js
+++ b/webapp/src/hooks/useIntersect.js
@@ -26,9 +26,11 @@ const defaultOption = {
 export default function useIntersect(callback, customOption) {
   const loadMoreRef = useRef(null);
 
-  const handleObsever = ([entry]) => {
+  const handleObsever = async ([entry], observer) => {
     if (entry.isIntersecting) {
-      callback();
+      observer.unobserve(entry.target);
+      await callback();
+      observer.observe(entry.target);
     }
   };
 

--- a/webapp/src/hooks/useIntersect.js
+++ b/webapp/src/hooks/useIntersect.js
@@ -19,20 +19,16 @@ const defaultOption = {
 
 /**
  * IntersectionObserver를 사용하기 위한 custom hoooks
+ * @param {callback} callback 바라보고 있는 요소가 교차할 때(isIntersecting) 실행할 callback함수
  * @param {Object} customOption  IntersectionObserver인스턴스를 생성하기 위한 option (root, rootMargin,threshold)  https://developer.mozilla.org/ko/docs/Web/API/IntersectionObserver/IntersectionObserver
  * @returns {useIntersectReturns}  useIntersect를 사용하는 곳에서 사용할 method 및 state
  */
-export default function useIntersect(customOption) {
-  const [page, setPage] = useState(0);
+export default function useIntersect(callback, customOption) {
   const loadMoreRef = useRef(null);
-
-  const resetPage = () => {
-    setPage(0);
-  };
 
   const handleObsever = ([entry]) => {
     if (entry.isIntersecting) {
-      setPage((prev) => prev + 1);
+      callback();
     }
   };
 
@@ -44,5 +40,5 @@ export default function useIntersect(customOption) {
     }
     return () => observer && observer.current && observer.disconnect();
   }, [customOption, loadMoreRef]);
-  return [loadMoreRef, page, resetPage];
+  return [loadMoreRef];
 }

--- a/webapp/src/pages/TeamBoard/TeamBoard.stories.jsx
+++ b/webapp/src/pages/TeamBoard/TeamBoard.stories.jsx
@@ -1,3 +1,7 @@
+import CardsGrid from 'components/CardsGrid';
+import TeamCard from 'components/TeamCard';
+import { ROUTE } from 'constant/route.constant';
+import { emptyTrigger } from 'constant/service.constant';
 import handlers from 'mocks/handlers';
 import React from 'react';
 import TeamBoard from './index';
@@ -15,5 +19,19 @@ function Template(args) {
   return <TeamBoard {...args} />;
 }
 
+function EmptyTemplate() {
+  return (
+    <CardsGrid
+      CardComponent={TeamCard}
+      cards={[]}
+      clickLink={`${ROUTE.TEAM}/`}
+      emptyTrigger={emptyTrigger.team}
+    />
+  );
+}
+
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Empty = EmptyTemplate.bind({});
+Empty.args = {};

--- a/webapp/src/pages/TeamBoard/index.jsx
+++ b/webapp/src/pages/TeamBoard/index.jsx
@@ -3,18 +3,18 @@ import teamApi from 'api/team.api';
 import TeamCard from 'components/TeamCard';
 import { ROUTE } from 'constant/route.constant';
 import WithInfiniteScroll from 'hoc/WithInfiniteScroll';
-import CardsGrid from 'components/CardsGrid';
+import { emptyTrigger } from 'constant/service.constant';
 import * as S from './style';
 
 export default function TeamBoard() {
-  const UserCardsGridWithInfiniteScroll = WithInfiniteScroll({
-    Component: CardsGrid,
-    responseDataKey: 'cards',
-    axiosInstance: teamApi.GET_TEAM_ARR,
-  });
   return (
     <S.BoardWrapper>
-      <UserCardsGridWithInfiniteScroll CardComponent={TeamCard} clickLink={`${ROUTE.TEAM}/`} />
+      <WithInfiniteScroll
+        CardComponent={TeamCard}
+        clickLink={`${ROUTE.TEAM}/`}
+        axiosInstance={teamApi.GET_TEAM_ARR}
+        emptyTrigger={emptyTrigger.team}
+      />
     </S.BoardWrapper>
   );
 }

--- a/webapp/src/pages/UserBoard/UserBoard.stories.jsx
+++ b/webapp/src/pages/UserBoard/UserBoard.stories.jsx
@@ -1,3 +1,7 @@
+import CardsGrid from 'components/CardsGrid';
+import UserCard from 'components/UserCard';
+import { ROUTE } from 'constant/route.constant';
+import { emptyTrigger } from 'constant/service.constant';
 import handlers from 'mocks/handlers';
 import React from 'react';
 import UserBoard from './index';
@@ -15,5 +19,19 @@ function Template(args) {
   return <UserBoard {...args} />;
 }
 
+function EmptyTemplate() {
+  return (
+    <CardsGrid
+      CardComponent={UserCard}
+      cards={[]}
+      clickLink={`${ROUTE.USER}/`}
+      emptyTrigger={emptyTrigger.user}
+    />
+  );
+}
+
 export const Default = Template.bind({});
 Default.args = {};
+
+export const Empty = EmptyTemplate.bind({});
+Empty.args = {};

--- a/webapp/src/pages/UserBoard/index.jsx
+++ b/webapp/src/pages/UserBoard/index.jsx
@@ -2,19 +2,21 @@ import React from 'react';
 import userApi from 'api/user.api';
 import UserCard from 'components/UserCard';
 import { ROUTE } from 'constant/route.constant';
+import UpperButton from 'components/Common/UpperButton';
 import WithInfiniteScroll from 'hoc/WithInfiniteScroll';
-import CardsGrid from 'components/CardsGrid';
+import { emptyTrigger } from 'constant/service.constant';
 import * as S from './style';
 
 export default function UserBoard() {
-  const UserCardsGridWithInfiniteScroll = WithInfiniteScroll({
-    Component: CardsGrid,
-    responseDataKey: 'cards',
-    axiosInstance: userApi.GET_USER_LIST,
-  });
   return (
     <S.BoardWrapper>
-      <UserCardsGridWithInfiniteScroll CardComponent={UserCard} clickLink={`${ROUTE.USER}/`} />
+      <WithInfiniteScroll
+        CardComponent={UserCard}
+        clickLink={`${ROUTE.USER}/`}
+        axiosInstance={userApi.GET_USER_LIST}
+        emptyTrigger={emptyTrigger.user}
+      />
+      <UpperButton />
     </S.BoardWrapper>
   );
 }


### PR DESCRIPTION
# About

1. 무한스크롤 버그 수정 
2. 유저 및 팀 보드 비었을 때 유도 UI추가

# Description

## 1. 무한스크롤 버그 수정 

기대 동작: 타겟 요소가 view port를 통과하면 등록된 callback함수 실행해야 합니다.

- 버그1: 타겟 요소가 view port를 통과해도 callback함수가 실행되지 않습니다. 
- 버그2: 해당 컴포넌트가 처음 렌더링시 fetch 요청을 두 번 보냅니다. (page가 0인 상태로 두 번 호출합니다. )

### 버그1 수정 30b055f356a2f2d4d4e1bd7f5975c993921d9387

정확한 원인은 파악하지 못했습니다. `useIntersect.js`라는 custom hooks를 범용성 있게 리팩토링하면서 버그1을 해결했습니다. (isIntersecting할 때 실행할 함수를 callback으로 넘겨 받도록 수정)

### 버그2 수정 2ee56c0d6d90a1f025c0984c1473fb30b14f1891

한 컴포넌트에 useEffect를 두 번 사용했기 때문에 발생한 문제였습니다. 필요없는 useEffect를 제거하면서 버그를 해결했습니다. 

## 2. 유저 및 팀 보드 비었을 때 유도 UI추가 2ee56c0d6d90a1f025c0984c1473fb30b14f1891

등록된 유저가 없거나, 등록된 팀이 없을 때 보드에 표시할 UI를 구현했습니다 .

- 등록된 유저가 없을 때 -> 회원가입 페이지로 유도
- 등록된 팀이 없을 때 -> 팀 생성 페이지로 유도

# Result

- 등록된 유저가 없을 때 -> 회원가입 페이지로 유도
<img width="648" alt="스크린샷 2022-12-26 오후 6 38 57" src="https://user-images.githubusercontent.com/71386219/209533019-f163186c-f666-4ded-81c8-f0b8493301be.png">

- 등록된 팀이 없을 때 -> 팀 생성 페이지로 유도
<img width="505" alt="스크린샷 2022-12-26 오후 6 39 09" src="https://user-images.githubusercontent.com/71386219/209533036-6a0388fe-4a01-4e9f-9991-83053a3af170.png">

- refetcher 이후 다시 잘 동작하는 무한스크롤 


https://user-images.githubusercontent.com/71386219/209533282-c116890c-f001-48f4-9bd1-52606ec80942.mov
