### PR TITLE
[FE] 무한스크롤 로딩 동작 수정

### DIFF
--- a/webapp/src/components/CardsGrid/index.jsx
+++ b/webapp/src/components/CardsGrid/index.jsx
@@ -26,7 +26,9 @@ export default function CardsGrid({ CardComponent, cards, isLoading, clickLink, 
   };
   const handleClickTriggerLink = () => navaigate(triggerLink);
 
-  if (isLoading)
+  // 기존 카드 길이도 없고 로딩인 상황 : 초기 렌더링 -> 이 때만 전체 페이지 로딩 표시
+  // 기존 카드는 있고 로딩인 상황 : 기존 카드는 그대로 보여지고 맨 아래 로딩 처리만
+  if (cards.length === 0 && isLoading)
     return (
       <S.Cards>
         <SimpleListComponent Component={CardLoader} idx={3} />

--- a/webapp/src/hoc/WithInfiniteScroll.jsx
+++ b/webapp/src/hoc/WithInfiniteScroll.jsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import styled from 'styled-components/macro';
 import PropTypes from 'prop-types';
 import useIntersect from 'hooks/useIntersect';
 import UpperButton from 'components/Common/UpperButton';
@@ -42,7 +43,7 @@ export default function WithInfiniteScroll({
 
   const fetcher = async (signal) => {
     setIsLoading(true);
-    setRefDisplay(DISPLAY.none);
+    // setRefDisplay(DISPLAY.none);
     try {
       const { data: responseCardList } = await axiosInstance({
         params: { lastPage: page.current },
@@ -100,10 +101,15 @@ export default function WithInfiniteScroll({
           isLoading={isLoading}
         />
       )}
-      <div style={{ display: refDisplay }} ref={loadMoreRef}>
+      <RefContainer isShow={refDisplay} ref={loadMoreRef}>
         {isLoading && !error.isError && <CardLoader />}
-      </div>
+      </RefContainer>
       <UpperButton />
     </>
   );
 }
+
+const RefContainer = styled.div`
+  display: ${({ isShow }) => isShow};
+  padding: 12px 0;
+`;


### PR DESCRIPTION
# About

무한스크롤 로딩 동작 수정

# Description

### 수정 전

기존에 카드 배열이 있을 시 추가 로드되는 상황 => 전체 페이지가 로딩 UI로 변함

### 수정 후

기존에 카드 배열이 있을 시 추가 로드되는 상황 => 화면 제일 하단부에 로딩 UI 추가

# 결과

![ezgif com-gif-maker-2](https://user-images.githubusercontent.com/71386219/210731784-6c0026b1-0cb7-498b-8848-4c049a497dfa.gif)

